### PR TITLE
Validate baseInr parameter in geo price API

### DIFF
--- a/app/api/geo-price/route.ts
+++ b/app/api/geo-price/route.ts
@@ -27,7 +27,14 @@ const INR_RATES: Record<string, { rate: number; symbol: string }> = {
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
-    const baseInr = Number(searchParams.get("baseInr") || "0");
+    const baseInrParam = searchParams.get("baseInr");
+    const baseInr = Number(baseInrParam);
+    if (!baseInrParam || !Number.isFinite(baseInr) || baseInr <= 0) {
+      return NextResponse.json(
+        { error: "Invalid or missing baseInr" },
+        { status: 400 }
+      );
+    }
 
     // Works on Vercel: picks first IP in x-forwarded-for if present
     const fwd = (req.headers.get("x-forwarded-for") || "").split(",")[0].trim();


### PR DESCRIPTION
## Summary
- ensure geo-price API validates `baseInr` query param and returns 400 on invalid input

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689e14b4b5d883278a94e030e74f701c