### PR TITLE
Initialize DealCountdown timer

### DIFF
--- a/app/components/DealCountdown.tsx
+++ b/app/components/DealCountdown.tsx
@@ -9,7 +9,8 @@ type Props = {
 };
 
 export default function DealCountdown({ minutes = 10, anchorId = "#pricing" }: Props) {
-  const [remaining, setRemaining] = useState<number>(0);
+  // Start with the full duration so the timer doesn't briefly show 0:00
+  const [remaining, setRemaining] = useState<number>(minutes * 60 * 1000);
   const [dismissed, setDismissed] = useState(false);
   const intervalRef = useRef<number | null>(null);
 


### PR DESCRIPTION
## Summary
- initialize DealCountdown remaining time with full duration to prevent 0:00 flash

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e24d23f308327b0bca322189f1dc7