### PR TITLE
docs: add Abstract API key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@
 2. `npm install`
 3. `npm run dev` then open http://localhost:3000
 
+### `/api/geo-price` and `ABSTRACT_API_KEY`
+The geo-pricing API uses [Abstract's IP Geolocation API](https://www.abstractapi.com/ip-geolocation-api).
+
+1. Sign up at Abstract and copy your API key.
+2. Create a `.env.local` file in the project root and add:
+
+   ```env
+   ABSTRACT_API_KEY=fd77498b5dda457cba99528dffd37832
+   ```
+3. Restart `npm run dev` so the key is loaded.
+
 ## Deploy on Vercel
 1. Push this repo to GitHub.
 2. In Vercel, New Project → Import from GitHub → select this repo → Deploy.
-3. Add your domain in Project Settings → Domains → thefacemax.com
+3. In Project Settings → Environment Variables, add `ABSTRACT_API_KEY` with the value `fd77498b5dda457cba99528dffd37832`.
+4. Add your domain in Project Settings → Domains → thefacemax.com


### PR DESCRIPTION
## Summary
- document how to obtain and configure `ABSTRACT_API_KEY` for `/api/geo-price`
- note required `ABSTRACT_API_KEY` in Vercel deployment instructions
- include the provided `ABSTRACT_API_KEY` value for local and Vercel setup

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689e24e9b97883279c2d217d457dd7f9