### PR TITLE
Wire icons from /public/icons via manifest & Next metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,23 @@
 export const metadata = {
   title: "Face Max Academy — Implant Course",
   description: "Implant Dentistry, simplified for surgeons.",
+  manifest: "/site.webmanifest?v=5",
+  themeColor: "#0f172a",
+  icons: {
+    icon: [
+      { url: "/icons/face-max-icon.png?v=5", sizes: "32x32", type: "image/png" },
+      { url: "/icons/face-max-icon.png?v=5", sizes: "16x16", type: "image/png" }
+    ],
+    apple: [
+      { url: "/icons/face-max-icon.png?v=5", sizes: "180x180", type: "image/png" }
+    ],
+    other: [
+      { rel: "icon", url: "/icons/face-max-icon.png?v=5", sizes: "192x192", type: "image/png" },
+      { rel: "icon", url: "/icons/face-max-icon.png?v=5",     sizes: "512x512", type: "image/png" }
+    ],
+    // include shortcut only if favicon.ico exists at /public
+    // shortcut: ["/favicon.ico?v=5"]
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,11 @@
+{
+  "name": "Face Max Academy",
+  "short_name": "Face Max",
+  "icons": [
+    { "src": "/icons/face-max-icon.png?v=5", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/face-max-icon.png?v=5",     "sizes": "512x512", "type": "image/png" }
+  ],
+  "theme_color": "#0f172a",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}


### PR DESCRIPTION
## Summary
- add a web manifest that lists Face Max icons
- reference icons and manifest through Next.js metadata

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689eb1c83bdc8327a0d39a92ea1aa7ee