### PR TITLE
Smooth MotionReveal on tablets (optimize whileInView, disable stagger on small)

### DIFF
--- a/app/components/MotionReveal.tsx
+++ b/app/components/MotionReveal.tsx
@@ -1,24 +1,69 @@
 "use client";
-import { motion } from "framer-motion";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import {
+  LazyMotion,
+  domAnimation,
+  m,
+  useReducedMotion,
+} from "framer-motion";
 
 type Props = {
   children: React.ReactNode;
-  delay?: number;      // seconds
-  y?: number;          // pixels to rise from
+  delay?: number; // seconds
+  y?: number; // pixels to rise from
   className?: string;
 };
+export default function MotionReveal({
+  children,
+  delay = 0,
+  y = 8,
+  className,
+}: Props) {
+  const prefersReduced = useReducedMotion();
 
-export default function MotionReveal({ children, delay = 0, y = 12, className }: Props) {
+  const [isSmall, setIsSmall] = useState(false);
+  useEffect(() => {
+    const mq = matchMedia("(hover: none)");
+    const update = () => {
+      const hoverNone = mq.matches;
+      const widthSmall = window.innerWidth <= 1024;
+      setIsSmall(hoverNone || widthSmall);
+    };
+    update();
+    mq.addEventListener("change", update);
+    window.addEventListener("resize", update);
+    return () => {
+      mq.removeEventListener("change", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  const finalDelay = isSmall ? 0 : delay;
+  const finalDuration = prefersReduced ? 0 : isSmall ? 0.35 : 0.45;
+
+  const [played, setPlayed] = useState(prefersReduced);
+
   return (
-    <motion.div
-      className={className}
-      initial={{ opacity: 0, y, filter: "blur(8px)" }}
-      whileInView={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-      transition={{ duration: 0.6, ease: "easeOut", delay }}
-      viewport={{ once: true, amount: 0.2 }}
-    >
-      {children}
-    </motion.div>
+    <LazyMotion features={domAnimation}>
+      <m.div
+        className={className}
+        style={played ? undefined : { willChange: "transform, opacity" }}
+        initial={{
+          opacity: prefersReduced ? 1 : 0,
+          y: prefersReduced ? 0 : y,
+        }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{
+          type: "tween",
+          duration: finalDuration,
+          ease: [0.22, 1, 0.36, 1],
+          delay: finalDelay,
+        }}
+        viewport={{ once: true, amount: 0.2, margin: "0px 0px -10% 0px" }}
+        onAnimationComplete={() => setPlayed(true)}
+      >
+        {children}
+      </m.div>
+    </LazyMotion>
   );
 }


### PR DESCRIPTION
## Summary
- lighten MotionReveal with LazyMotion and once-only whileInView viewport
- respect prefers-reduced-motion and drop delays on small/hover-none devices

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689eb94f9c80832784e2e48ce6b9cc71