### PR TITLE
feat(vdocipher): add dynamic moving watermark via OTP annotation_code

### DIFF
--- a/VDOCIPHER.md
+++ b/VDOCIPHER.md
@@ -8,3 +8,8 @@
 
 ## Environment Variable
 - Set the `VDOCIPHER_API_SECRET` environment variable in Vercel for the endpoint to authenticate with VdoCipher.
+
+## Watermark
+- Optional `viewerName` and `viewerEmail` fields can be passed to `/api/get-otp` to render personalized watermark text.
+- The annotation also includes built-in `{{ip}}` and `{{timestamp}}` tokens and moves on screen (`movable: true`).
+- The API secret remains hidden; it should live in the Vercel environment variable `VDOCIPHER_API_SECRET`.

--- a/app/api/get-otp/route.ts
+++ b/app/api/get-otp/route.ts
@@ -2,37 +2,56 @@ import { NextResponse } from "next/server";
 
 async function handler(request: Request) {
   let videoId: string | undefined;
+  let viewerName: string | undefined;
+  let viewerEmail: string | undefined;
 
   if (request.method === "GET") {
     const url = new URL(request.url);
     videoId = url.searchParams.get("videoId") || undefined;
+    viewerName = url.searchParams.get("viewerName") || undefined;
+    viewerEmail = url.searchParams.get("viewerEmail") || undefined;
   } else {
     try {
       const body = await request.json();
       videoId = body.videoId;
+      viewerName = body.viewerName;
+      viewerEmail = body.viewerEmail;
     } catch (e) {
       videoId = undefined;
     }
   }
 
+  const headers = {
+    "Cache-Control": "no-store",
+    "Access-Control-Allow-Origin": new URL(request.url).origin,
+  } as const;
+
   if (!videoId) {
-    return NextResponse.json(
-      { error: "videoId required" },
-      {
-        status: 400,
-        headers: { "Cache-Control": "no-store", "Access-Control-Allow-Origin": new URL(request.url).origin },
-      }
-    );
+    return NextResponse.json({ error: "videoId required" }, { status: 400, headers });
+  }
+
+  const apiSecret = process.env.VDOCIPHER_API_SECRET;
+  if (!apiSecret) {
+    return NextResponse.json({ error: "VDOCIPHER_API_SECRET not set" }, { status: 500, headers });
   }
 
   try {
+    const annotationText = `Licensed to ${viewerName || "Student"} · ${viewerEmail || "thefacemax.com"} · {{ip}} · {{timestamp}}`;
+
     const apiRes = await fetch(`https://dev.vdocipher.com/api/videos/${videoId}/otp`, {
       method: "POST",
       headers: {
-        Authorization: `Apisecret ${process.env.VDOCIPHER_API_SECRET}`,
+        Authorization: `Apisecret ${apiSecret}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ ttl: 300 }),
+      body: JSON.stringify({
+        ttl: 300,
+        annotation_code: {
+          text: annotationText,
+          style: "font-size:16px; color:white; text-shadow: 0 0 3px #000; opacity:0.22;",
+          movable: true,
+        },
+      }),
     });
 
     if (!apiRes.ok) {
@@ -44,18 +63,12 @@ async function handler(request: Request) {
 
     return NextResponse.json(
       { otp: data.otp, playbackInfo: data.playbackInfo },
-      {
-        status: 200,
-        headers: { "Cache-Control": "no-store", "Access-Control-Allow-Origin": new URL(request.url).origin },
-      }
+      { status: 200, headers }
     );
   } catch (error: any) {
     return NextResponse.json(
       { error: error.message || "Unknown error" },
-      {
-        status: 500,
-        headers: { "Cache-Control": "no-store", "Access-Control-Allow-Origin": new URL(request.url).origin },
-      }
+      { status: 500, headers }
     );
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -219,8 +219,11 @@ export default function Page() {
       <script
         dangerouslySetInnerHTML={{
           __html: `
-            const VIDEO_ID = "056ef4706ec54b21baa09deccbb710f7";
-            fetch(\`/api/get-otp?videoId=\${encodeURIComponent(VIDEO_ID)}\`, { cache: 'no-store' })
+              const VIDEO_ID = "056ef4706ec54b21baa09deccbb710f7";
+              const params = new URLSearchParams({ videoId: VIDEO_ID });
+              if (window.viewerName) params.append('viewerName', window.viewerName);
+              if (window.viewerEmail) params.append('viewerEmail', window.viewerEmail);
+              fetch(\`/api/get-otp?\${params.toString()}\`, { cache: 'no-store' })
               .then(res => res.json())
               .then(({ otp, playbackInfo }) => {
                 const iframe = document.getElementById('vdoplayer');


### PR DESCRIPTION
## Summary
- add optional viewer data and dynamic watermark to VdoCipher OTP endpoint
- pass viewer name/email from landing page when available
- document personalized, moving watermark support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4423a7bf88327bcfe6f8fc5c16ce9