### PR TITLE
feat(vdocipher): personalized moving watermark via annotate

### DIFF
--- a/VDOCIPHER.md
+++ b/VDOCIPHER.md
@@ -11,5 +11,25 @@
 
 ## Watermark
 - Optional `viewerName` and `viewerEmail` fields can be passed to `/api/get-otp` to render personalized watermark text.
-- The annotation also includes built-in `{{ip}}` and `{{timestamp}}` tokens and moves on screen (`movable: true`).
+- The annotation also includes built-in `{ip}` and `{date.h:i:s A}` tokens and moves on screen.
 - The API secret remains hidden; it should live in the Vercel environment variable `VDOCIPHER_API_SECRET`.
+
+## Usage
+
+```ts
+--- GET example ---
+fetch(`/api/get-otp?videoId=VIDEO_ID&viewerName=${encodeURIComponent(name)}&viewerEmail=${encodeURIComponent(email)}`, { cache: "no-store" })
+  .then(r => r.json())
+  .then(({ otp, playbackInfo }) => {
+    document.getElementById("vdoplayer").src =
+      `https://player.vdocipher.com/v2/?otp=${encodeURIComponent(otp)}&playbackInfo=${encodeURIComponent(playbackInfo)}`;
+  });
+
+--- POST example ---
+await fetch("/api/get-otp", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  cache: "no-store",
+  body: JSON.stringify({ videoId: "VIDEO_ID", viewerName: name, viewerEmail: email })
+}).then(r => r.json()).then(({ otp, playbackInfo }) => { /* set iframe src as above */ });
+```

--- a/app/api/get-otp/route.ts
+++ b/app/api/get-otp/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
 
+function sanitize(input?: string) {
+  if (!input) return undefined;
+  return input.trim().slice(0, 64).replace(/[<>"']/g, "");
+}
+
 async function handler(request: Request) {
   let videoId: string | undefined;
   let viewerName: string | undefined;
@@ -35,6 +40,23 @@ async function handler(request: Request) {
     return NextResponse.json({ error: "VDOCIPHER_API_SECRET not set" }, { status: 500, headers });
   }
 
+  viewerName = sanitize(viewerName);
+  viewerEmail = sanitize(viewerEmail);
+
+  const safeName = viewerName || "Student";
+  const safeEmail = viewerEmail || "thefacemax.com";
+
+  const wmItems = [
+    {
+      type: "rtext",
+      text: ` Licensed to ${safeName} · ${safeEmail} · {ip} · {date.h:i:s A} `,
+      alpha: "0.22",
+      color: "0xFFFFFF",
+      size: "16",
+      interval: "5000",
+    },
+  ];
+
   try {
     const apiRes = await fetch(`https://dev.vdocipher.com/api/videos/${videoId}/otp`, {
       method: "POST",
@@ -44,16 +66,7 @@ async function handler(request: Request) {
       },
       body: JSON.stringify({
         ttl: 300,
-        annotate: JSON.stringify([
-          {
-            type: "rtext",
-            text: "Licensed to {ip} · {date.h:i:s A}",
-            alpha: "0.25",
-            color: "0xFFFFFF",
-            size: "16",
-            interval: "5000",
-          },
-        ]),
+        annotate: JSON.stringify(wmItems),
       }),
     });
 


### PR DESCRIPTION
## Summary
- personalize VdoCipher watermark with optional viewer name and email
- document OTP fetch examples for GET and POST usage

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a3e1dcf08327b0ba03aa87a2b491