### PR TITLE
feat: add email helper and test route

### DIFF
--- a/app/api/test-email/route.ts
+++ b/app/api/test-email/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { sendEmail } from '@/app/lib/email';
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const to = searchParams.get('to');
+    if (!to) return NextResponse.json({ ok: false, error: 'missing ?to=' }, { status: 400 });
+
+    const r = await sendEmail(
+      to,
+      'The Face Max — test email ✅',
+      `<p>Hello from the site. If you got this, Resend + domain setup works.</p>`
+    );
+    return NextResponse.json({ ok: true, result: r });
+  } catch (e: any) {
+    console.error(e);
+    return NextResponse.json({ ok: false, error: e.message ?? 'send failed' }, { status: 500 });
+  }
+}

--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -1,0 +1,15 @@
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function sendEmail(to: string, subject: string, html: string) {
+  if (!process.env.RESEND_API_KEY || !process.env.EMAIL_FROM) {
+    throw new Error('Missing RESEND_API_KEY or EMAIL_FROM');
+  }
+  return await resend.emails.send({
+    from: process.env.EMAIL_FROM!,
+    to,
+    subject,
+    html,
+  });
+}


### PR DESCRIPTION
## Summary
- add Resend email helper
- create test route to verify email sending

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d39a5238832784f142e621a969e0