### PR TITLE
chore: load Resend API key from env

### DIFF
--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -1,7 +1,11 @@
 // app/lib/email.ts
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const resendApiKey = process.env.RESEND_API_KEY;
+if (!resendApiKey) {
+  console.error('Missing RESEND_API_KEY in environment variables');
+}
+const resend = new Resend(resendApiKey);
 
 export async function sendEmail(to: string, subject: string, html: string) {
   if (!process.env.RESEND_API_KEY || !process.env.EMAIL_FROM) {


### PR DESCRIPTION
## Summary
- initialize Resend with RESEND_API_KEY from environment
- log an error if RESEND_API_KEY is missing

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a5df738e9883279648f41b151ff15c