### PR TITLE
feat(auth): DB tables + login with password → email OTP + temp create-test-user route + UI wiring

### DIFF
--- a/app/api/auth/login-otp/route.ts
+++ b/app/api/auth/login-otp/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { ensureTables } from '@/app/lib/bootstrap';
+import { hashToken } from '@/app/lib/crypto';
+import { setSession } from '@/app/lib/cookies';
+
+export async function POST(req: Request) {
+  await ensureTables();
+  const { email, code } = await req.json();
+  if (!email || !code) return NextResponse.json({ error: 'Email and code required' }, { status: 400 });
+  const users = await sql<{id:string,name:string,email:string}[]>`SELECT id, name, email FROM users WHERE email=${email.toLowerCase()} LIMIT 1;`;
+  if (users.length === 0) return NextResponse.json({ error: 'Invalid code' }, { status: 401 });
+  const u = users[0];
+
+  const otps = await sql<{id:string,expires_at:string,consumed_at:string|null}[]>`
+    SELECT id, expires_at, consumed_at FROM otps 
+    WHERE user_id=${u.id} AND purpose='login' 
+    ORDER BY created_at DESC LIMIT 5;
+  `;
+  // Check the latest non-consumed OTP
+  const now = new Date();
+  let validId: string | null = null;
+  for (const o of otps) {
+    if (o.consumed_at) continue;
+    const exp = new Date(o.expires_at);
+    if (exp < now) continue;
+    // compare hash
+    const [{ ok }] = await sql<{ok:boolean}[]>`SELECT ${hashToken(code)} = code_hash as ok FROM otps WHERE id=${o.id};`;
+    if (ok) { validId = o.id; break; }
+  }
+  if (!validId) return NextResponse.json({ error: 'Invalid or expired code' }, { status: 401 });
+
+  await sql`UPDATE otps SET consumed_at=now() WHERE id=${validId};`;
+  setSession({ userId: u.id, name: u.name, email: u.email });
+  return NextResponse.json({ ok: true, redirect: '/course' });
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { ensureTables } from '@/app/lib/bootstrap';
+import { verifyPassword, hashToken, randomId } from '@/app/lib/crypto';
+import { generateOtp, expiresIn } from '@/app/lib/otp';
+import { sendEmail } from '@/app/lib/email';
+
+export async function POST(req: Request) {
+  await ensureTables();
+  const { email, password } = await req.json();
+  if (!email || !password) return NextResponse.json({ error: 'Email and password required' }, { status: 400 });
+  const rows = await sql<{id:string,name:string,password_hash:string}[]>`SELECT id, name, password_hash FROM users WHERE email=${email.toLowerCase()} LIMIT 1;`;
+  if (rows.length === 0) return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+  const user = rows[0];
+  const ok = await verifyPassword(password, user.password_hash);
+  if (!ok) return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+
+  const code = generateOtp(6);
+  const exp = expiresIn(10);
+  const otpId = randomId();
+  await sql`INSERT INTO otps(id, user_id, code_hash, purpose, expires_at) VALUES(${otpId}, ${user.id}, ${hashToken(code)}, 'login', ${exp});`;
+
+  await sendEmail(email, 'Your FaceMax login code', `
+    <p>Hello ${user.name},</p>
+    <p>Your login code is: <b style="font-size:18px">${code}</b></p>
+    <p>This code expires in 10 minutes.</p>
+  `);
+
+  return NextResponse.json({ otpRequired: true, email });
+}

--- a/app/api/dev/create-test-user/route.ts
+++ b/app/api/dev/create-test-user/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { ensureTables } from '@/app/lib/bootstrap';
+import { hashPassword } from '@/app/lib/crypto';
+import { randomId } from '@/app/lib/crypto';
+
+export async function POST(req: Request) {
+  await ensureTables();
+  const { name, email, password } = await req.json();
+  if (!name || !email || !password) return NextResponse.json({ error: 'name, email, password required' }, { status: 400 });
+  const id = randomId();
+  const pw = await hashPassword(password);
+  try {
+    await sql`INSERT INTO users(id, email, name, password_hash) VALUES(${id}, ${email.toLowerCase()}, ${name}, ${pw});`;
+    return NextResponse.json({ ok: true, userId: id });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+}

--- a/app/lib/bootstrap.ts
+++ b/app/lib/bootstrap.ts
@@ -1,0 +1,19 @@
+import { sql } from '../lib/db';
+export async function ensureTables() {
+  await sql`CREATE TABLE IF NOT EXISTS users(
+    id uuid PRIMARY KEY,
+    email text UNIQUE NOT NULL,
+    name text NOT NULL,
+    password_hash text NOT NULL,
+    created_at timestamptz DEFAULT now()
+  );`;
+  await sql`CREATE TABLE IF NOT EXISTS otps(
+    id uuid PRIMARY KEY,
+    user_id uuid NOT NULL,
+    code_hash text NOT NULL,
+    purpose text NOT NULL CHECK (purpose in ('login')),
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz NULL,
+    created_at timestamptz DEFAULT now()
+  );`;
+}

--- a/app/lib/cookies.ts
+++ b/app/lib/cookies.ts
@@ -1,0 +1,11 @@
+import { cookies } from 'next/headers';
+type Sess = { userId: string, name: string, email: string };
+const COOKIE = 'fm_session';
+export function setSession(sess: Sess) {
+  cookies().set(COOKIE, JSON.stringify(sess), { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 60*60*24*30 });
+}
+export function getSession(): Sess | null {
+  const c = cookies().get(COOKIE)?.value; if (!c) return null;
+  try { return JSON.parse(c); } catch { return null; }
+}
+export function clearSession() { cookies().delete(COOKIE); }

--- a/app/lib/crypto.ts
+++ b/app/lib/crypto.ts
@@ -1,0 +1,6 @@
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+export async function hashPassword(p: string) { return await bcrypt.hash(p, 10); }
+export async function verifyPassword(p: string, hash: string) { return await bcrypt.compare(p, hash); }
+export function hashToken(v: string) { return crypto.createHash('sha256').update(v).digest('hex'); }
+export function randomId() { return crypto.randomUUID(); }

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,0 +1,3 @@
+import { neon } from '@neondatabase/serverless';
+if (!process.env.POSTGRES_URL) throw new Error('POSTGRES_URL missing');
+export const sql = neon(process.env.POSTGRES_URL);

--- a/app/lib/otp.ts
+++ b/app/lib/otp.ts
@@ -1,0 +1,7 @@
+export function generateOtp(n = 6) {
+  let s = ''; for (let i = 0; i < n; i++) s += Math.floor(Math.random()*10);
+  return s;
+}
+export function expiresIn(minutes = 10) {
+  const d = new Date(); d.setMinutes(d.getMinutes() + minutes); return d;
+}

--- a/app/login/otp/page.tsx
+++ b/app/login/otp/page.tsx
@@ -1,12 +1,31 @@
 "use client";
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 
 export default function OtpPage() {
+  const search = useSearchParams();
+  const email = search.get("email") || "";
+  const [code, setCode] = useState("");
   const [message, setMessage] = useState("");
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setMessage("Verifying… (API next step)");
+    setMessage("");
+    const res = await fetch("/api/auth/login-otp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, code }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.ok) {
+        window.location.href = '/course';
+      }
+    } else if (res.status === 401) {
+      setMessage("Invalid code");
+    } else {
+      setMessage("Error");
+    }
   }
 
   return (
@@ -19,6 +38,8 @@ export default function OtpPage() {
           required
           className="w-full rounded border p-2 text-center tracking-widest"
           placeholder="123456"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
         />
         <button
           type="submit"
@@ -33,4 +54,3 @@ export default function OtpPage() {
     </div>
   );
 }
-

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,13 +1,32 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [message, setMessage] = useState("");
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setMessage("Submitting… (API will be added in the next step)");
+    setMessage("");
+    const res = await fetch("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.otpRequired) {
+        router.push(`/login/otp?email=${encodeURIComponent(email)}`);
+      }
+    } else if (res.status === 401) {
+      setMessage("Invalid credentials");
+    } else {
+      setMessage("Error");
+    }
   }
 
   return (
@@ -18,12 +37,16 @@ export default function LoginPage() {
           required
           placeholder="Email"
           className="w-full rounded border p-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
         />
         <input
           type="password"
           required
           placeholder="Password"
           className="w-full rounded border p-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
         />
         <button
           type="submit"
@@ -46,4 +69,3 @@ export default function LoginPage() {
     </div>
   );
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@neondatabase/serverless": "^1.0.1",
+        "bcryptjs": "^3.0.2",
         "framer-motion": "11.2.10",
         "lucide-react": "0.469.0",
         "next": "14.2.5",
@@ -2023,6 +2024,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.1",
+    "bcryptjs": "^3.0.2",
     "framer-motion": "11.2.10",
     "lucide-react": "0.469.0",
     "next": "14.2.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,10 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- add PostgreSQL helpers and OTP utilities for authentication
- implement password login that emails 6-digit OTP, verify OTP and set session cookie
- wire login pages and provide temporary dev route to create test user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5e9f410c083279dcab981c472892f