### PR TITLE
fix(build): remove sql generics and wrap search params

### DIFF
--- a/app/api/auth/login-otp/route.ts
+++ b/app/api/auth/login-otp/route.ts
@@ -8,15 +8,15 @@ export async function POST(req: Request) {
   await ensureTables();
   const { email, code } = await req.json();
   if (!email || !code) return NextResponse.json({ error: 'Email and code required' }, { status: 400 });
-  const users = await sql<{id:string,name:string,email:string}[]>`SELECT id, name, email FROM users WHERE email=${email.toLowerCase()} LIMIT 1;`;
+  const users = (await sql`SELECT id, name, email FROM users WHERE email=${email.toLowerCase()} LIMIT 1;`) as { id: string; name: string; email: string }[];
   if (users.length === 0) return NextResponse.json({ error: 'Invalid code' }, { status: 401 });
   const u = users[0];
 
-  const otps = await sql<{id:string,expires_at:string,consumed_at:string|null}[]>`
-    SELECT id, expires_at, consumed_at FROM otps 
-    WHERE user_id=${u.id} AND purpose='login' 
+  const otps = (await sql`
+    SELECT id, expires_at, consumed_at FROM otps
+    WHERE user_id=${u.id} AND purpose='login'
     ORDER BY created_at DESC LIMIT 5;
-  `;
+  `) as { id: string; expires_at: string; consumed_at: string | null }[];
   // Check the latest non-consumed OTP
   const now = new Date();
   let validId: string | null = null;
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
     const exp = new Date(o.expires_at);
     if (exp < now) continue;
     // compare hash
-    const [{ ok }] = await sql<{ok:boolean}[]>`SELECT ${hashToken(code)} = code_hash as ok FROM otps WHERE id=${o.id};`;
+    const [{ ok }] = (await sql`SELECT ${hashToken(code)} = code_hash as ok FROM otps WHERE id=${o.id};`) as { ok: boolean }[];
     if (ok) { validId = o.id; break; }
   }
   if (!validId) return NextResponse.json({ error: 'Invalid or expired code' }, { status: 401 });

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -9,7 +9,7 @@ export async function POST(req: Request) {
   await ensureTables();
   const { email, password } = await req.json();
   if (!email || !password) return NextResponse.json({ error: 'Email and password required' }, { status: 400 });
-  const rows = await sql<{id:string,name:string,password_hash:string}[]>`SELECT id, name, password_hash FROM users WHERE email=${email.toLowerCase()} LIMIT 1;`;
+  const rows = (await sql`SELECT id, name, password_hash FROM users WHERE email=${email.toLowerCase()} LIMIT 1;`) as { id: string; name: string; password_hash: string }[];
   if (rows.length === 0) return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
   const user = rows[0];
   const ok = await verifyPassword(password, user.password_hash);

--- a/app/login/otp/page.tsx
+++ b/app/login/otp/page.tsx
@@ -1,8 +1,16 @@
 "use client";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 export default function OtpPage() {
+  return (
+    <Suspense>
+      <OtpForm />
+    </Suspense>
+  );
+}
+
+function OtpForm() {
   const search = useSearchParams();
   const email = search.get("email") || "";
   const [code, setCode] = useState("");
@@ -47,9 +55,7 @@ export default function OtpPage() {
         >
           Verify OTP
         </button>
-        {message && (
-          <p className="text-center text-sm">{message}</p>
-        )}
+        {message && <p className="text-center text-sm">{message}</p>}
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove generics from sql tagged template usages
- wrap OTP login page in Suspense to satisfy `useSearchParams` requirement

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5f77f96e48327897f5d8c111394d3