### PR TITLE
test(admin): add/remove temporary debug endpoints for live verification

### DIFF
--- a/app/api/admin/lectures/route.ts
+++ b/app/api/admin/lectures/route.ts
@@ -1,4 +1,7 @@
 // app/api/admin/lectures/route.ts
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import { ensureTables } from '@/app/lib/bootstrap';

--- a/app/api/admin/sections/route.ts
+++ b/app/api/admin/sections/route.ts
@@ -1,4 +1,7 @@
 // app/api/admin/sections/route.ts
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import { ensureTables } from '@/app/lib/bootstrap';

--- a/app/api/admin/vdocipher-videos/route.ts
+++ b/app/api/admin/vdocipher-videos/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { assertAdmin } from '@/app/lib/admin';
 
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 export async function GET(req: Request) {
   try {


### PR DESCRIPTION
## Summary
- temporarily added debug endpoints `_health`, `_whoami` and admin `_check` page to verify sessions
- removed debug routes and enforced dynamic caching for admin APIs

## Testing
- `npm test`
- `curl -iL https://thefacemax.com/api/admin/sections` (401)
- `curl -iL https://thefacemax.com/api/admin/lectures` (401)
- `curl -iL https://thefacemax.com/api/admin/vdocipher-videos` (401)


------
https://chatgpt.com/codex/tasks/task_e_68a632ac747c83279005cd8838e098df