### PR TITLE
Fix admin section creation flow

### DIFF
--- a/app/admin/course/CreateSectionForm.tsx
+++ b/app/admin/course/CreateSectionForm.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function CreateSectionForm({ nextIndex }: { nextIndex: number }) {
+  const [title, setTitle] = useState('');
+  const [orderIndex, setOrderIndex] = useState(String(nextIndex));
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/admin/sections', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, orderIndex: Number(orderIndex) }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) {
+      setError(data?.error || 'Failed to create section');
+      return;
+    }
+    setTitle('');
+    setOrderIndex(String(nextIndex + 1));
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <label style={{ display: 'block', fontWeight: 600, marginBottom: 6 }}>Title</label>
+      <input
+        name="title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        required
+        placeholder="e.g. Basic Anatomy for Implantology"
+        style={{ width: '100%', border: '1px solid #d1d5db', borderRadius: 8, padding: '10px 12px' }}
+      />
+      <div style={{ height: 12 }} />
+      <label style={{ display: 'block', fontWeight: 600, marginBottom: 6 }}>Order Index</label>
+      <input
+        type="number"
+        name="orderIndex"
+        value={orderIndex}
+        onChange={(e) => setOrderIndex(e.target.value)}
+        style={{ width: '100%', border: '1px solid #d1d5db', borderRadius: 8, padding: '10px 12px' }}
+      />
+      <div style={{ height: 12 }} />
+      {error && <p style={{ color: '#ef4444', marginBottom: 12 }}>{error}</p>}
+      <button
+        type="submit"
+        style={{ background: '#111827', color: '#fff', borderRadius: 8, padding: '10px 14px', fontWeight: 600 }}
+      >
+        Create Section
+      </button>
+    </form>
+  );
+}
+

--- a/app/admin/course/page.tsx
+++ b/app/admin/course/page.tsx
@@ -4,7 +4,7 @@ export const revalidate = 0;
 import { isAdmin } from '@/app/lib/admin';
 import { ensureTables } from '@/app/lib/bootstrap';
 import { sql } from '@/app/lib/db';
-import { revalidatePath } from 'next/cache';
+import CreateSectionForm from './CreateSectionForm';
 
 export default async function AdminCoursePage() {
   if (!isAdmin()) {
@@ -22,45 +22,7 @@ export default async function AdminCoursePage() {
         {/* Create Section */}
         <section style={{ border: '1px solid #e5e7eb', borderRadius: 12, padding: 16 }}>
           <h2 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>Create Section</h2>
-          <form
-            action={async (formData) => {
-              'use server';
-              const sectionTitle = String(formData.get('title') || '').trim();
-              const orderIndex = String(formData.get('orderIndex') || '0');
-              await fetch('/api/admin/sections', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                  title: sectionTitle,
-                  orderIndex: Number(orderIndex),
-                }),
-              });
-              revalidatePath('/admin/course');
-            }}
-          >
-            <label style={{ display: 'block', fontWeight: 600, marginBottom: 6 }}>Title</label>
-            <input
-              name="title"
-              required
-              placeholder="e.g. Basic Anatomy for Implantology"
-              style={{ width: '100%', border: '1px solid #d1d5db', borderRadius: 8, padding: '10px 12px' }}
-            />
-            <div style={{ height: 12 }} />
-            <label style={{ display: 'block', fontWeight: 600, marginBottom: 6 }}>Order Index</label>
-            <input
-              type="number"
-              name="orderIndex"
-              defaultValue={sections.length}
-              style={{ width: '100%', border: '1px solid #d1d5db', borderRadius: 8, padding: '10px 12px' }}
-            />
-            <div style={{ height: 12 }} />
-            <button
-              type="submit"
-              style={{ background: '#111827', color: '#fff', borderRadius: 8, padding: '10px 14px', fontWeight: 600 }}
-            >
-              Create Section
-            </button>
-          </form>
+          <CreateSectionForm nextIndex={sections.length} />
         </section>
 
         {/* Add/Update Lecture */}

--- a/app/api/admin/sections/route.ts
+++ b/app/api/admin/sections/route.ts
@@ -1,15 +1,22 @@
 // app/api/admin/sections/route.ts
+import "server-only";
 import { NextResponse } from "next/server";
 import { sql } from "@/app/lib/db";
 import { ensureTables } from "@/app/lib/bootstrap";
-import { requireAdminEmail } from "@/app/lib/admin";
+import { getSession } from "@/app/lib/cookies";
+import { randomId } from "@/app/lib/crypto";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {
-    requireAdminEmail();
+    const session = getSession();
+    const admin = process.env.ADMIN_EMAIL?.toLowerCase().trim() || "";
+    if (!session?.email || session.email.toLowerCase() !== admin) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
     await ensureTables();
 
     const rows = (await sql`
@@ -19,43 +26,38 @@ export async function GET() {
     `) as { id: string; title: string; order_index: number }[];
 
     return NextResponse.json({ ok: true, sections: rows });
-  } catch (e: any) {
-    const status = e?.status || 500;
-    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status });
+  } catch (err) {
+    console.error("[admin/sections] failed:", err);
+    return NextResponse.json({ ok: false, error: "Server error" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   try {
-    requireAdminEmail();
-    await ensureTables();
-
-    const body = await req.json().catch(() => ({}));
-    const titleRaw = String(body?.title ?? "").trim();
-    const orderRaw = body?.orderIndex ?? body?.order_index ?? 0;
-
-    if (!titleRaw) {
-      return NextResponse.json({ ok: false, error: "Title is required" }, { status: 400 });
+    const session = getSession();
+    const admin = process.env.ADMIN_EMAIL?.toLowerCase().trim() || "";
+    if (!session?.email || session.email.toLowerCase() !== admin) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const orderIndex = Number.parseInt(String(orderRaw), 10);
-    const orderSafe = Number.isFinite(orderIndex) ? orderIndex : 0;
+    await ensureTables();
 
-    // Insert (id generated in DB default or use random if your schema needs it)
+    const { title, orderIndex } = await req.json().catch(() => ({} as any));
+    const name = (title ?? "").toString().trim();
+    const idx = Number.isFinite(Number(orderIndex)) ? Number(orderIndex) : 0;
+    if (!name || name.length > 120) {
+      return NextResponse.json({ ok: false, error: "Invalid title" }, { status: 400 });
+    }
+
+    const id = randomId();
     await sql`
-      INSERT INTO sections (title, order_index)
-      VALUES (${titleRaw}, ${orderSafe})
+      INSERT INTO sections (id, title, order_index)
+      VALUES (${id}, ${name}, ${idx})
     `;
 
-    const rows = (await sql`
-      SELECT id, title, order_index
-      FROM sections
-      ORDER BY order_index ASC, created_at ASC
-    `) as { id: string; title: string; order_index: number }[];
-
-    return NextResponse.json({ ok: true, sections: rows });
-  } catch (e: any) {
-    const status = e?.status || 500;
-    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status });
+    return NextResponse.json({ ok: true, id, title: name, orderIndex: idx });
+  } catch (err) {
+    console.error("[admin/sections] failed:", err);
+    return NextResponse.json({ ok: false, error: "Server error" }, { status: 500 });
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,9 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.jest.json',

--- a/tests/admin-sections.test.ts
+++ b/tests/admin-sections.test.ts
@@ -1,0 +1,78 @@
+process.env.POSTGRES_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: any, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), { status: init?.status || 200 }),
+  },
+}));
+
+jest.mock('server-only', () => ({}), { virtual: true });
+
+jest.mock('../app/lib/db', () => ({
+  sql: jest.fn(),
+}));
+
+jest.mock('../app/lib/bootstrap', () => ({
+  ensureTables: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../app/lib/cookies', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('../app/lib/crypto', () => ({
+  randomId: () => 'new-id',
+}));
+
+import { POST } from '../app/api/admin/sections/route';
+import { getCourseData } from '../app/lib/course-data';
+
+const { sql } = require('../app/lib/db');
+const { getSession } = require('../app/lib/cookies');
+
+beforeEach(() => {
+  process.env.ADMIN_EMAIL = 'admin@example.com';
+  sql.mockReset();
+});
+
+describe('admin sections POST', () => {
+  it('returns 401 when not admin', async () => {
+    getSession.mockReturnValue({ email: 'user@example.com' });
+    const req = new Request('http://localhost/api/admin/sections', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'A', orderIndex: 0 }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+  });
+
+  it('creates section when admin', async () => {
+    getSession.mockReturnValue({ email: 'admin@example.com' });
+    sql.mockResolvedValueOnce(undefined);
+    const req = new Request('http://localhost/api/admin/sections', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Hello', orderIndex: 1 }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, id: 'new-id', title: 'Hello', orderIndex: 1 });
+  });
+});
+
+describe('course data loader', () => {
+  it('returns created sections', async () => {
+    sql
+      .mockImplementationOnce(async () => [
+        { id: 'new-id', title: 'Hello', order_index: 1 },
+      ])
+      .mockImplementationOnce(async () => []);
+    const data = await getCourseData();
+    expect(data.length).toBe(1);
+    expect(data[0].title).toBe('Hello');
+  });
+});
+


### PR DESCRIPTION
## Summary
- harden admin sections API with session-based auth, validation, and safe inserts
- add client-side CreateSection form with inline errors and refresh
- test admin sections API and course loader

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74404095c83278fae2253eb1fce71