### PR TITLE
chore: specify runtime and dynamic for test-email route

### DIFF
--- a/app/api/test-email/route.ts
+++ b/app/api/test-email/route.ts
@@ -1,4 +1,7 @@
 // app/api/test-email/route.ts
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { sendEmail } from '../../lib/email'; // <-- relative path
 


### PR DESCRIPTION
## Summary
- ensure `/api/test-email` is executed in the Node.js runtime and always rendered dynamically

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7782ecd788327adb688b3abfdc213