### PR TITLE
refactor: convert set password page to server component

### DIFF
--- a/app/auth/set-password/SetPasswordForm.tsx
+++ b/app/auth/set-password/SetPasswordForm.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+
+interface SetPasswordFormProps {
+  token: string;
+}
+
+export default function SetPasswordForm({ token }: SetPasswordFormProps) {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setMessage("");
+    if (password !== confirmPassword) {
+      setMessage("Passwords do not match");
+      return;
+    }
+    const res = await fetch("/api/auth/set-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, password }),
+    });
+    if (res.ok) {
+      setMessage("Password updated");
+    } else {
+      setMessage("Error");
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+      <input
+        type="password"
+        required
+        placeholder="New password"
+        className="w-full rounded border p-2"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <input
+        type="password"
+        required
+        placeholder="Confirm password"
+        className="w-full rounded border p-2"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="w-full rounded bg-slate-900 py-2 text-white"
+      >
+        Set Password
+      </button>
+      {message && <p className="text-center text-sm">{message}</p>}
+    </form>
+  );
+}

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -1,0 +1,14 @@
+import SetPasswordForm from "./SetPasswordForm";
+
+interface PageProps {
+  searchParams: { token?: string };
+}
+
+export default function SetPasswordPage({ searchParams }: PageProps) {
+  const token = searchParams.token ?? "";
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <SetPasswordForm token={token} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add set-password page as a server component that passes the token from search params to a client form
- implement SetPasswordForm client component to handle password reset submission

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a77a903b688327837d92fae5ae7ea8