### PR TITLE
Handle purchase webhooks and password setup

### DIFF
--- a/app/api/auth/set-password/route.ts
+++ b/app/api/auth/set-password/route.ts
@@ -1,0 +1,50 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { ensureTables } from '@/app/lib/bootstrap';
+import { hashPassword, hashToken } from '@/app/lib/crypto';
+import { setSession } from '@/app/lib/cookies';
+
+export async function POST(req: Request) {
+  await ensureTables();
+  const { token, password } = await req.json();
+  if (!token || !password)
+    return NextResponse.json(
+      { error: 'Token and password required' },
+      { status: 400 }
+    );
+
+  const tokenHash = hashToken(token);
+  const rows = (await sql`
+    SELECT pr.id, pr.user_id, pr.expires_at, pr.consumed_at, u.name, u.email
+    FROM password_resets pr
+    JOIN users u ON pr.user_id = u.id
+    WHERE pr.token_hash=${tokenHash}
+    LIMIT 1;
+  `) as {
+    id: string;
+    user_id: string;
+    expires_at: string;
+    consumed_at: string | null;
+    name: string;
+    email: string;
+  }[];
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 400 });
+  }
+
+  const row = rows[0];
+  if (row.consumed_at || new Date(row.expires_at) < new Date()) {
+    return NextResponse.json({ error: 'Expired token' }, { status: 400 });
+  }
+
+  const hash = await hashPassword(password);
+  await sql`UPDATE users SET password_hash=${hash} WHERE id=${row.user_id};`;
+  await sql`UPDATE password_resets SET consumed_at=now() WHERE id=${row.id};`;
+
+  setSession({ userId: row.user_id, name: row.name, email: row.email });
+  return NextResponse.json({ ok: true, redirect: '/course' });
+}

--- a/app/api/webhooks/razorpay/route.ts
+++ b/app/api/webhooks/razorpay/route.ts
@@ -1,0 +1,96 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { sql } from '@/app/lib/db';
+import { ensureTables } from '@/app/lib/bootstrap';
+import { randomId, hashToken, hashPassword } from '@/app/lib/crypto';
+import { sendEmail } from '@/app/lib/email';
+import { COURSE_ID } from '@/app/lib/course-ids';
+import { setPasswordEmail } from '@/app/emails/set-password';
+
+const RATE_LIMIT_MAX = 60;
+let rateCount = 0;
+let rateReset = Date.now();
+
+function rateLimited() {
+  const now = Date.now();
+  if (now > rateReset) {
+    rateReset = now + 60_000;
+    rateCount = 0;
+  }
+  rateCount++;
+  return rateCount > RATE_LIMIT_MAX;
+}
+
+export async function POST(req: Request) {
+  if (rateLimited()) {
+    console.error('razorpay webhook rate limited');
+    return NextResponse.json({ ok: false }, { status: 202 });
+  }
+
+  try {
+    const raw = await req.text();
+    const signature = req.headers.get('x-razorpay-signature') || '';
+    const secret = process.env.RAZORPAY_WEBHOOK_SECRET || '';
+    const expected = crypto
+      .createHmac('sha256', secret)
+      .update(raw)
+      .digest('hex');
+    if (
+      !signature ||
+      !crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
+    ) {
+      return NextResponse.json({ error: 'invalid signature' }, { status: 400 });
+    }
+
+    const event = JSON.parse(raw);
+    if (!['payment.captured', 'order.paid'].includes(event.event)) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const payment = event.payload?.payment?.entity || {};
+    const order = event.payload?.order?.entity || {};
+    const email = payment.email || order.email;
+    const name =
+      payment.notes?.name || payment.card?.name || order.notes?.name || '';
+    if (!email) return NextResponse.json({ ok: true });
+
+    await ensureTables();
+    const emailLower = email.toLowerCase();
+    const existing = (await sql`SELECT id, name FROM users WHERE email=${emailLower} LIMIT 1;`) as {
+      id: string;
+      name: string;
+    }[];
+    let userId: string;
+    let userName: string;
+    if (existing.length === 0) {
+      userId = randomId();
+      userName = name || emailLower;
+      const fakeHash = await hashPassword(randomId());
+      await sql`INSERT INTO users(id, email, name, password_hash) VALUES(${userId}, ${emailLower}, ${userName}, ${fakeHash});`;
+    } else {
+      userId = existing[0].id;
+      userName = existing[0].name;
+    }
+
+    await sql`INSERT INTO purchases(user_id, course_id) VALUES(${userId}, ${COURSE_ID}) ON CONFLICT DO NOTHING;`;
+
+    const token = randomId();
+    const tokenHash = hashToken(token);
+    await sql`INSERT INTO password_resets(id, user_id, token_hash, expires_at) VALUES(${randomId()}, ${userId}, ${tokenHash}, now() + interval '45 minutes');`;
+
+    const link = `https://thefacemax.com/auth/set-password?token=${token}`;
+    await sendEmail(
+      emailLower,
+      'Set your password for The Face Max',
+      setPasswordEmail(link)
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    console.error(e);
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,113 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { sql } from '@/app/lib/db';
+import { ensureTables } from '@/app/lib/bootstrap';
+import { randomId, hashToken, hashPassword } from '@/app/lib/crypto';
+import { sendEmail } from '@/app/lib/email';
+import { COURSE_ID } from '@/app/lib/course-ids';
+import { setPasswordEmail } from '@/app/emails/set-password';
+
+const RATE_LIMIT_MAX = 60;
+let rateCount = 0;
+let rateReset = Date.now();
+
+function rateLimited() {
+  const now = Date.now();
+  if (now > rateReset) {
+    rateReset = now + 60_000;
+    rateCount = 0;
+  }
+  rateCount++;
+  return rateCount > RATE_LIMIT_MAX;
+}
+
+function verifyStripeSignature(raw: string, sig: string | null, secret: string) {
+  if (!sig) return false;
+  const parts = sig.split(',').reduce<Record<string, string>>((acc, part) => {
+    const [k, v] = part.split('=');
+    if (k && v) acc[k] = v;
+    return acc;
+  }, {});
+  const timestamp = parts['t'];
+  const v1 = parts['v1'];
+  if (!timestamp || !v1) return false;
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${timestamp}.${raw}`)
+    .digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(v1));
+}
+
+export async function POST(req: Request) {
+  if (rateLimited()) {
+    console.error('stripe webhook rate limited');
+    return NextResponse.json({ ok: false }, { status: 202 });
+  }
+
+  try {
+    const raw = await req.text();
+    const sig = req.headers.get('stripe-signature');
+    const secret = process.env.STRIPE_WEBHOOK_SECRET || '';
+    if (!verifyStripeSignature(raw, sig, secret)) {
+      return NextResponse.json({ error: 'invalid signature' }, { status: 400 });
+    }
+
+    const event = JSON.parse(raw);
+    if (
+      ![
+        'checkout.session.completed',
+        'payment_intent.succeeded',
+        'invoice.paid',
+      ].includes(event.type)
+    ) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const obj = event.data?.object || {};
+    const email =
+      obj.customer_details?.email ||
+      obj.receipt_email ||
+      obj.email;
+    const name = obj.customer_details?.name || obj.customer_name || '';
+    if (!email) return NextResponse.json({ ok: true });
+
+    await ensureTables();
+    const emailLower = email.toLowerCase();
+    const existing = (await sql`SELECT id, name FROM users WHERE email=${emailLower} LIMIT 1;`) as {
+      id: string;
+      name: string;
+    }[];
+    let userId: string;
+    let userName: string;
+    if (existing.length === 0) {
+      userId = randomId();
+      userName = name || emailLower;
+      const fakeHash = await hashPassword(randomId());
+      await sql`INSERT INTO users(id, email, name, password_hash) VALUES(${userId}, ${emailLower}, ${userName}, ${fakeHash});`;
+    } else {
+      userId = existing[0].id;
+      userName = existing[0].name;
+    }
+
+    await sql`INSERT INTO purchases(user_id, course_id) VALUES(${userId}, ${COURSE_ID}) ON CONFLICT DO NOTHING;`;
+
+    const token = randomId();
+    const tokenHash = hashToken(token);
+    await sql`INSERT INTO password_resets(id, user_id, token_hash, expires_at) VALUES(${randomId()}, ${userId}, ${tokenHash}, now() + interval '45 minutes');`;
+
+    const link = `https://thefacemax.com/auth/set-password?token=${token}`;
+    await sendEmail(
+      emailLower,
+      'Set your password for The Face Max',
+      setPasswordEmail(link)
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    console.error(e);
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}

--- a/app/auth/set-password/SetPasswordForm.tsx
+++ b/app/auth/set-password/SetPasswordForm.tsx
@@ -31,6 +31,7 @@ export default function SetPasswordForm({ token }: SetPasswordFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+      <input type="hidden" name="token" value={token} />
       <input
         type="password"
         required

--- a/app/emails/set-password.ts
+++ b/app/emails/set-password.ts
@@ -1,0 +1,10 @@
+// app/emails/set-password.ts
+
+export function setPasswordEmail(link: string) {
+  return `
+    <p>Hello,</p>
+    <p>Thank you for your purchase of The Face Max course.</p>
+    <p><a href="${link}">Click here to set your password</a>. This link is valid for 45 minutes.</p>
+    <p>If you did not expect this email, you can ignore it.</p>
+  `;
+}

--- a/app/lib/bootstrap.ts
+++ b/app/lib/bootstrap.ts
@@ -69,6 +69,16 @@ export async function ensureTables() {
     );
   `;
 
+  await sql`
+    CREATE TABLE IF NOT EXISTS password_resets (
+      id          text PRIMARY KEY,
+      user_id     text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      token_hash  text NOT NULL,
+      expires_at  timestamptz NOT NULL,
+      consumed_at timestamptz
+    );
+  `;
+
   await sql`CREATE INDEX IF NOT EXISTS idx_sections_order ON sections(order_index, created_at);`;
   await sql`CREATE INDEX IF NOT EXISTS idx_lectures_section_order ON lectures(section_id, order_index, created_at);`;
 }


### PR DESCRIPTION
## Summary
- Add Stripe and Razorpay webhook endpoints with signature validation, rate limiting, and post-payment user provisioning
- Store password reset tokens and send set-password emails via Resend
- Provide API and client form for setting a new password

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7828f19b48327a86066f0933658bc