### PR TITLE
feat: allow admin to invite students

### DIFF
--- a/app/admin/course/InviteStudentForm.tsx
+++ b/app/admin/course/InviteStudentForm.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function InviteStudentForm() {
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    const res = await fetch('/api/admin/invite', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email.trim(), name: name.trim() || undefined }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) {
+      setError(data?.error || 'Failed to send invite');
+      return;
+    }
+    setSuccess('Invite sent');
+    setEmail('');
+    setName('');
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <label style={{ display: 'block', fontWeight: 600, marginBottom: 6 }}>Email</label>
+      <input
+        type="email"
+        name="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        placeholder="student@example.com"
+        style={{ width: '100%', border: '1px solid #d1d5db', borderRadius: 8, padding: '10px 12px' }}
+      />
+      <div style={{ height: 12 }} />
+      <label style={{ display: 'block', fontWeight: 600, marginBottom: 6 }}>Name (optional)</label>
+      <input
+        name="name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="e.g. Jane Doe"
+        style={{ width: '100%', border: '1px solid #d1d5db', borderRadius: 8, padding: '10px 12px' }}
+      />
+      <div style={{ height: 12 }} />
+      {error && <p style={{ color: '#ef4444', marginBottom: 12 }}>{error}</p>}
+      {success && <p style={{ color: '#10b981', marginBottom: 12 }}>{success}</p>}
+      <button
+        type="submit"
+        style={{ background: '#111827', color: '#fff', borderRadius: 8, padding: '10px 14px', fontWeight: 600 }}
+      >
+        Send Invite
+      </button>
+    </form>
+  );
+}

--- a/app/admin/course/page.tsx
+++ b/app/admin/course/page.tsx
@@ -6,6 +6,7 @@ import { ensureTables } from '@/app/lib/bootstrap';
 import { sql } from '@/app/lib/db';
 import CreateSectionForm from './CreateSectionForm';
 import CreateLectureForm from './CreateLectureForm';
+import InviteStudentForm from './InviteStudentForm';
 
 export default async function AdminCoursePage() {
   if (!isAdmin()) {
@@ -32,6 +33,14 @@ export default async function AdminCoursePage() {
           <CreateLectureForm sections={sections} />
         </section>
       </div>
+
+      <div style={{ height: 24 }} />
+
+      {/* Invite Student */}
+      <section style={{ border: '1px solid #e5e7eb', borderRadius: 12, padding: 16, maxWidth: 400 }}>
+        <h2 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>Invite Student</h2>
+        <InviteStudentForm />
+      </section>
 
       <div style={{ height: 28 }} />
       <h2 style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>Current Structure</h2>

--- a/app/api/admin/invite/route.ts
+++ b/app/api/admin/invite/route.ts
@@ -1,0 +1,57 @@
+import 'server-only';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { requireAdminEmail } from '@/app/lib/admin';
+import { ensureTables } from '@/app/lib/bootstrap';
+import { sql } from '@/app/lib/db';
+import { randomId, hashToken, hashPassword } from '@/app/lib/crypto';
+import { sendEmail } from '@/app/lib/email';
+import { COURSE_ID } from '@/app/lib/course-ids';
+import { setPasswordEmail } from '@/app/emails/set-password';
+
+export async function POST(req: Request) {
+  try {
+    requireAdminEmail();
+    await ensureTables();
+
+    const body = await req.json().catch(() => ({} as any));
+    const email = (body.email ?? '').toString().trim().toLowerCase();
+    const name = (body.name ?? '').toString().trim();
+
+    if (!email) {
+      return NextResponse.json({ ok: false, error: 'Email required' }, { status: 400 });
+    }
+
+    const existing = (await sql`SELECT id, name FROM users WHERE email=${email} LIMIT 1;`) as { id: string; name: string }[];
+    let userId: string;
+    if (existing.length === 0) {
+      userId = randomId();
+      const userName = name || email;
+      const fakeHash = await hashPassword(randomId());
+      await sql`INSERT INTO users(id, email, name, password_hash) VALUES(${userId}, ${email}, ${userName}, ${fakeHash});`;
+    } else {
+      userId = existing[0].id;
+      if (name && name !== existing[0].name) {
+        await sql`UPDATE users SET name=${name} WHERE id=${userId};`;
+      }
+    }
+
+    await sql`INSERT INTO purchases(user_id, course_id) VALUES(${userId}, ${COURSE_ID}) ON CONFLICT DO NOTHING;`;
+
+    const token = randomId();
+    const tokenHash = hashToken(token);
+    await sql`INSERT INTO password_resets(id, user_id, token_hash, expires_at) VALUES(${randomId()}, ${userId}, ${tokenHash}, now() + interval '45 minutes');`;
+
+    const link = `https://thefacemax.com/auth/set-password?token=${token}`;
+    await sendEmail(email, 'Set your password for The Face Max', setPasswordEmail(link));
+
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    console.error('[admin/invite] failed:', err);
+    const status = err.status || 500;
+    return NextResponse.json({ ok: false, error: err.message || 'Server error' }, { status });
+  }
+}


### PR DESCRIPTION
## Summary
- add admin invite endpoint that grants course access and emails set-password link
- add invite student form to admin course builder

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a78469947083278f97be4e386912a6