### PR TITLE
Add buyer password reset flow

### DIFF
--- a/app/api/auth/forgot/route.ts
+++ b/app/api/auth/forgot/route.ts
@@ -1,0 +1,45 @@
+import 'server-only';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { sql } from '@/app/lib/db';
+import { ensureTables } from '@/app/lib/bootstrap';
+import { randomId, hashToken } from '@/app/lib/crypto';
+import { sendEmail } from '@/app/lib/email';
+import { setPasswordEmail } from '@/app/emails/set-password';
+import { userHasPurchase } from '@/app/lib/access';
+import { COURSE_ID } from '@/app/lib/course-ids';
+
+const LIMIT_PER_DAY = 5;
+
+export async function POST(req: Request) {
+  try {
+    await ensureTables();
+    const body = await req.json().catch(() => ({} as any));
+    const email = (body.email ?? '').toString().trim().toLowerCase();
+    if (email) {
+      const users = (await sql`SELECT id FROM users WHERE email=${email} LIMIT 1;`) as { id: string }[];
+      if (users.length === 1) {
+        const userId = users[0].id;
+        const countRows = (await sql`
+          SELECT count(*)::int AS count
+          FROM password_resets
+          WHERE user_id=${userId} AND created_at > now() - interval '24 hours';
+        `) as { count: number }[];
+        const hasPurchase = await userHasPurchase(userId, COURSE_ID);
+        if (hasPurchase && (countRows[0]?.count ?? 0) < LIMIT_PER_DAY) {
+          const token = randomId();
+          const tokenHash = hashToken(token);
+          await sql`INSERT INTO password_resets(id, user_id, token_hash, expires_at) VALUES(${randomId()}, ${userId}, ${tokenHash}, now() + interval '45 minutes');`;
+          const link = `https://thefacemax.com/auth/set-password?token=${token}`;
+          await sendEmail(email, 'Reset your password', setPasswordEmail(link));
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[auth/forgot] failed:', err);
+  }
+  return NextResponse.json({ message: "If the account exists, we've sent instructions." });
+}

--- a/app/auth/forgot/page.tsx
+++ b/app/auth/forgot/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setMessage("");
+    await fetch("/api/auth/forgot", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+    setMessage("If the account exists, we've sent instructions.");
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <input
+          type="email"
+          required
+          placeholder="Email"
+          className="w-full rounded border p-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="w-full rounded bg-slate-900 py-2 text-white"
+        >
+          Send reset link
+        </button>
+        {message && (
+          <p className="text-center text-sm">{message}</p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/app/lib/bootstrap.ts
+++ b/app/lib/bootstrap.ts
@@ -75,9 +75,12 @@ export async function ensureTables() {
       user_id     text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       token_hash  text NOT NULL,
       expires_at  timestamptz NOT NULL,
-      consumed_at timestamptz
+      consumed_at timestamptz,
+      created_at  timestamptz DEFAULT now()
     );
   `;
+
+  await sql`ALTER TABLE password_resets ADD COLUMN IF NOT EXISTS created_at timestamptz DEFAULT now();`;
 
   await sql`CREATE INDEX IF NOT EXISTS idx_sections_order ON sections(order_index, created_at);`;
   await sql`CREATE INDEX IF NOT EXISTS idx_lectures_section_order ON lectures(section_id, order_index, created_at);`;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -59,7 +59,7 @@ export default function LoginPage() {
         )}
         <div className="text-center">
           <Link
-            href="/forgot"
+            href="/auth/forgot"
             className="text-sm text-slate-600 underline"
           >
             Forgot password?


### PR DESCRIPTION
## Summary
- add client-side forgot-password page and link from login
- implement API to send reset emails with 45‑minute tokens and daily rate limit
- track reset requests with created_at column for auditing

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a787d27ba48327af7bbed808a45cd9