### PR TITLE
style(course): match landing theme + rounded syllabus cards (no animations)

### DIFF
--- a/app/course/page.tsx
+++ b/app/course/page.tsx
@@ -1,4 +1,11 @@
 // app/course/page.tsx
+// Theme tokens (from landing page)
+// bg: bg-gradient-to-b from-white to-slate-50
+// surface: bg-white
+// border: border-slate-200
+// text: text-slate-900
+// muted: text-slate-600
+// accent: text-amber-400
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
@@ -30,16 +37,16 @@ export default async function CoursePage() {
   const totalLectures = data.reduce((a, s) => a + s.lectures.length, 0);
 
   return (
-    <div className="min-h-screen bg-white text-[#111]">
-      <div className="border-b border-neutral-200">
-        <div className="mx-auto max-w-[1200px] px-4 py-3 flex items-center gap-3">
-          <div className="font-semibold">The Face Max</div>
-          <div className="text-neutral-400">|</div>
-          <div className="text-sm text-neutral-600">Dental Implant Mastery</div>
+    <div className="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-900">
+      <div className="border-b border-slate-200/60 bg-white/70">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center gap-3">
+          <div className="font-semibold">Face Max Academy</div>
+          <div className="text-slate-400">|</div>
+          <div className="text-sm text-slate-600">Dental Implant Mastery</div>
         </div>
       </div>
 
-      <div className="mx-auto max-w-[1200px] px-4 py-6 grid grid-cols-1 lg:grid-cols-[1fr,360px] gap-24">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8 grid grid-cols-1 lg:grid-cols-[1fr,360px] gap-24">
         <CourseClient data={data} totalLectures={totalLectures} />
       </div>
     </div>

--- a/app/course/ui.tsx
+++ b/app/course/ui.tsx
@@ -1,5 +1,13 @@
 'use client';
 
+// Theme tokens (from landing page)
+// bg: bg-gradient-to-b from-white to-slate-50
+// surface: bg-white
+// border: border-slate-200
+// text: text-slate-900
+// muted: text-slate-600
+// accent: text-amber-400
+
 import { useEffect, useMemo, useState } from 'react';
 
 type Lecture = {
@@ -86,13 +94,13 @@ export default function CourseClient({
     <>
       {/* LEFT: player + details */}
       <div>
-        <div className="aspect-video w-full rounded-sm bg-black overflow-hidden border border-neutral-200 relative">
+        <div className="aspect-video w-full rounded-lg bg-black overflow-hidden border border-slate-200 relative">
           {!playerSrc && (
-            <div className="absolute inset-0 flex items-center justify-center text-white/70 text-sm">
+            <div className="absolute inset-0 flex items-center justify-center text-slate-400 text-sm">
               {loading ? 'Loading secure player…' : 'Select a lecture'}
             </div>
           )}
-        {playerSrc && (
+          {playerSrc && (
             <iframe
               key={playerSrc}
               src={playerSrc}
@@ -105,92 +113,96 @@ export default function CourseClient({
           )}
         </div>
 
-        <div className="mt-4">
-          <h1 className="text-xl font-semibold leading-snug">{active?.title || '—'}</h1>
-          <p className="text-sm text-neutral-600 mt-1">
+        <div className="mt-6">
+          <h1 className="text-2xl md:text-3xl font-bold leading-snug">{active?.title || '—'}</h1>
+          <p className="mt-2 text-sm text-slate-600">
             {index > 0 ? `Lesson ${String(index).padStart(2, '0')}` : 'Lesson'} • {active?.duration || '—'}
           </p>
         </div>
 
         {/* Tabs (minimal) */}
-        <div className="mt-6 border-b border-neutral-200">
+        <div className="mt-8 border-b border-slate-200">
           <div className="flex gap-6 text-sm">
-            <button className="py-3 border-b-2 border-black font-medium">Overview</button>
-            <button className="py-3 text-neutral-600">Notes</button>
-            <button className="py-3 text-neutral-600">Announcements</button>
-            <button className="py-3 text-neutral-600">Learning tools</button>
+            <button className="py-3 font-semibold text-slate-900">Overview</button>
+            <button className="py-3 text-slate-600">Notes</button>
+            <button className="py-3 text-slate-600">Announcements</button>
+            <button className="py-3 text-slate-600">Learning tools</button>
           </div>
         </div>
 
-        <div className="mt-4 text-sm leading-6 text-neutral-700">
+        <div className="mt-6 text-sm leading-6 text-slate-700">
           This program covers anatomy, planning, surgery, prosthetics and complications with secure DRM video playback.
         </div>
       </div>
 
-      {/* RIGHT: sticky accordion */}
-      <aside className="lg:sticky lg:top-6 h-fit">
-        <div className="border border-neutral-200 rounded-sm">
-          <div className="px-4 py-3 border-b border-neutral-200">
-            <div className="text-sm font-semibold">Course content</div>
-            <div className="text-xs text-neutral-500 mt-1">
-              {totalLectures} lectures
-            </div>
-          </div>
+      {/* RIGHT: syllabus cards */}
+      <aside className="lg:sticky lg:top-24 h-fit space-y-6">
+        <div>
+          <div className="text-sm font-semibold">Course content</div>
+          <div className="text-xs text-slate-600 mt-1">{totalLectures} lectures</div>
+        </div>
 
-          <div className="divide-y divide-neutral-200">
-            {data.map((sec) => {
-              const isOpen = open[sec.id];
-              return (
-                <div key={sec.id}>
-                  <button
-                    className="w-full px-4 py-3 flex items-center justify-between"
-                    onClick={() => setOpen((m) => ({ ...m, [sec.id]: !m[sec.id] }))}
-                  >
-                    <div className="text-sm font-medium text-left">
-                      {sec.order}. {sec.title}
-                    </div>
-                    <div className="flex items-center gap-3">
-                      <span className="text-xs text-neutral-500">
-                        {sec.lectures.length} lecture{sec.lectures.length === 1 ? '' : 's'}
-                      </span>
-                      <span className="text-neutral-400">{isOpen ? '▾' : '▸'}</span>
-                    </div>
-                  </button>
+        {data.length === 0 ? (
+          <p className="text-sm text-slate-600">No sections yet</p>
+        ) : (
+          data.map((sec) => {
+            const isOpen = open[sec.id];
+            return (
+              <div key={sec.id} className="rounded-lg border border-slate-200 bg-white">
+                <button
+                  className="w-full px-4 py-3 flex items-center justify-between rounded-t-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                  onClick={() => setOpen((m) => ({ ...m, [sec.id]: !m[sec.id] }))}
+                >
+                  <div className="flex items-center gap-2 text-sm font-medium text-left">
+                    <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+                    <span>{sec.title}</span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-slate-600">
+                      {sec.lectures.length} lecture{sec.lectures.length === 1 ? '' : 's'}
+                    </span>
+                    <span className="text-slate-400">{isOpen ? '▾' : '▸'}</span>
+                  </div>
+                </button>
 
-                  {isOpen && (
+                {isOpen && (
+                  sec.lectures.length === 0 ? (
+                    <p className="px-4 py-3 text-sm text-slate-600">No lectures yet</p>
+                  ) : (
                     <ul className="px-2 py-2">
                       {sec.lectures.map((lec) => {
                         const activeRow = active?.id === lec.id;
                         return (
-                          <li key={lec.id} className={['rounded-sm', activeRow ? 'bg-neutral-100' : ''].join(' ')}>
+                          <li key={lec.id}>
                             <button
                               onClick={() => setActive(lec)}
-                              className="w-full px-3 py-2 flex items-center gap-3 text-left"
+                              className={[
+                                'w-full px-3 py-2 rounded-sm flex items-center gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400',
+                                activeRow ? 'bg-slate-100' : 'hover:bg-slate-50',
+                              ].join(' ')}
                             >
                               <input
                                 type="checkbox"
-                                className="mt-[1px] h-4 w-4"
+                                className="mt-[1px] h-4 w-4 rounded accent-amber-400"
                                 checked={!!done[lec.id]}
                                 onChange={(e) => setDone((d) => ({ ...d, [lec.id]: e.target.checked }))}
                                 onClick={(e) => e.stopPropagation()}
                               />
-                              <div className="flex-1">
-                                <div className={['text-sm', activeRow ? 'font-medium' : 'text-neutral-800'].join(' ')}>
-                                  {lec.title}
-                                </div>
-                                <div className="text-xs text-neutral-500 mt-[2px]">{lec.duration}</div>
-                              </div>
+                              <span className={['flex-1 text-sm', activeRow ? 'font-medium text-slate-900' : 'text-slate-900'].join(' ')}>
+                                {lec.title}
+                              </span>
+                              <span className="text-xs text-slate-600">{lec.duration}</span>
                             </button>
                           </li>
                         );
                       })}
                     </ul>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
+                  )
+                )}
+              </div>
+            );
+          })
+        )}
       </aside>
     </>
   );


### PR DESCRIPTION
## Summary
- restyle course page background and container to reuse landing theme
- polish player/metadata and switch tabs to clean text
- render sticky syllabus with rounded section cards and lecture rows

## Testing
- `npm test`
- `npm run lint`

## Screenshots
![Desktop](course-desktop-auth.png)
![Mobile](course-mobile-auth.png)


------
https://chatgpt.com/codex/tasks/task_e_68a7d82cd6d48327a395a862838e3aa3