### PR TITLE
feat(db): payments and password token helpers

### DIFF
--- a/app/lib/bootstrap.ts
+++ b/app/lib/bootstrap.ts
@@ -68,26 +68,25 @@ export async function ensureTables() {
     CREATE TABLE IF NOT EXISTS payments (
       id TEXT PRIMARY KEY,
       provider TEXT NOT NULL,
-      payment_id TEXT NOT NULL,
       email TEXT NOT NULL,
-      amount INTEGER,       -- store in minor units if available
-      currency TEXT,
-      raw JSONB,            -- store full webhook for audit
-      created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+      amount INTEGER NOT NULL,
+      currency TEXT NOT NULL,
+      payload JSONB NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     );
   `;
 
-  // PASSWORD RESET TOKENS
+  // PASSWORD TOKENS
   await sql`
-    CREATE TABLE IF NOT EXISTS password_reset_tokens (
-      token_id TEXT PRIMARY KEY,
-      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      token_hash TEXT NOT NULL,
-      purpose TEXT NOT NULL, -- 'set-password' or 'reset-password'
-      expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
-      created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+    CREATE TABLE IF NOT EXISTS password_tokens (
+      token TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      purpose TEXT NOT NULL CHECK (purpose IN ('set','reset')),
+      expires_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     );
   `;
+  await sql`CREATE INDEX IF NOT EXISTS idx_password_tokens_email ON password_tokens(email);`;
 
   done = true;
 }

--- a/app/lib/crypto.ts
+++ b/app/lib/crypto.ts
@@ -1,22 +1,63 @@
-// app/lib/crypto.ts
-import { randomBytes, scryptSync, timingSafeEqual, createHmac, createHash } from "crypto";
+import { randomBytes, scryptSync, timingSafeEqual, createHash } from 'crypto';
+import { sql } from '@/app/lib/db';
 
-// app/lib/crypto.ts (append these helpers)
-import { randomBytes, timingSafeEqual } from "crypto";
-
-export function createPlainToken(): string {
-  return randomBytes(24).toString("hex"); // 48-char
+export function randomId(len = 32): string {
+  return randomBytes(len / 2).toString('hex');
 }
 
-// Compares two hex-encoded hashes in constant-time
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export async function hashPassword(plain: string): Promise<string> {
+  const salt = randomBytes(16).toString('hex');
+  const derived = scryptSync(plain, salt, 64).toString('hex');
+  return `${salt}:${derived}`;
+}
+
+export async function verifyPassword(plain: string, hash: string): Promise<boolean> {
+  const [salt, key] = hash.split(':');
+  if (!salt || !key) return false;
+  const derived = scryptSync(plain, salt, 64);
+  const keyBuf = Buffer.from(key, 'hex');
+  return derived.length === keyBuf.length && timingSafeEqual(derived, keyBuf);
+}
+
+export async function issuePasswordToken(
+  email: string,
+  purpose: 'set' | 'reset',
+  ttlMinutes = 60
+): Promise<string> {
+  const token = randomId(48);
+  const expires = new Date(Date.now() + ttlMinutes * 60_000);
+  await sql`INSERT INTO password_tokens(token, email, purpose, expires_at) VALUES(${token}, ${email}, ${purpose}, ${expires});`;
+  return token;
+}
+
+export async function consumePasswordToken(
+  token: string,
+  expectedPurpose: 'set' | 'reset'
+): Promise<{ email: string } | null> {
+  const rows = (await sql`
+    DELETE FROM password_tokens
+    WHERE token=${token} AND purpose=${expectedPurpose} AND expires_at > now()
+    RETURNING email;
+  `) as { email: string }[];
+  if (rows.length === 0) return null;
+  return { email: rows[0].email };
+}
+
+export function createPlainToken(): string {
+  return randomBytes(24).toString('hex');
+}
+
 export function safeEqualHex(a: string, b: string): boolean {
   try {
-    const aBuf = Buffer.from(a, "hex");
-    const bBuf = Buffer.from(b, "hex");
+    const aBuf = Buffer.from(a, 'hex');
+    const bBuf = Buffer.from(b, 'hex');
     return aBuf.length === bBuf.length && timingSafeEqual(aBuf, bBuf);
   } catch {
     return false;
   }
 }
-
 


### PR DESCRIPTION
## Summary
- log Razorpay/Stripe payments in new `payments` table
- manage password reset/set flows via `password_tokens`
- add crypto helpers for password hashing and token issuance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad2fb52ac88327ac0eebcf3c8513d5