### PR TITLE
feat(auth): set-password page + API (token-based)

### DIFF
--- a/app/api/auth/set-password/route.ts
+++ b/app/api/auth/set-password/route.ts
@@ -4,47 +4,35 @@ export const dynamic = 'force-dynamic';
 import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import { ensureTables } from '@/app/lib/bootstrap';
-import { hashPassword, hashToken } from '@/app/lib/crypto';
+import { hashPassword, consumePasswordToken } from '@/app/lib/crypto';
 import { setSession } from '@/app/lib/cookies';
 
 export async function POST(req: Request) {
   await ensureTables();
-  const { token, password } = await req.json();
-  if (!token || !password)
+  const { token, password } = await req.json().catch(() => ({}) as any);
+  if (!token || !password) {
     return NextResponse.json(
       { error: 'Token and password required' },
       { status: 400 }
     );
-
-  const tokenHash = hashToken(token);
-  const rows = (await sql`
-    SELECT pr.id, pr.user_id, pr.expires_at, pr.consumed_at, u.name, u.email
-    FROM password_resets pr
-    JOIN users u ON pr.user_id = u.id
-    WHERE pr.token_hash=${tokenHash}
-    LIMIT 1;
-  `) as {
-    id: string;
-    user_id: string;
-    expires_at: string;
-    consumed_at: string | null;
-    name: string;
-    email: string;
-  }[];
-
-  if (rows.length === 0) {
-    return NextResponse.json({ error: 'Invalid token' }, { status: 400 });
   }
 
-  const row = rows[0];
-  if (row.consumed_at || new Date(row.expires_at) < new Date()) {
-    return NextResponse.json({ error: 'Expired token' }, { status: 400 });
+  const consumed = await consumePasswordToken(token, 'set');
+  if (!consumed) {
+    return NextResponse.json({ error: 'Invalid or expired token' }, { status: 400 });
   }
 
+  const users = (await sql`
+    SELECT id, name FROM users WHERE email=${consumed.email} LIMIT 1;
+  `) as { id: string; name: string }[];
+  if (users.length === 0) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 });
+  }
+
+  const user = users[0];
   const hash = await hashPassword(password);
-  await sql`UPDATE users SET password_hash=${hash} WHERE id=${row.user_id};`;
-  await sql`UPDATE password_resets SET consumed_at=now() WHERE id=${row.id};`;
+  await sql`UPDATE users SET password_hash=${hash} WHERE id=${user.id};`;
 
-  setSession({ userId: row.user_id, name: row.name, email: row.email });
+  setSession({ userId: user.id, name: user.name, email: consumed.email });
   return NextResponse.json({ ok: true, redirect: '/course' });
 }

--- a/app/auth/set-password/SetPasswordForm.tsx
+++ b/app/auth/set-password/SetPasswordForm.tsx
@@ -25,8 +25,17 @@ export default function SetPasswordForm({ token }: SetPasswordFormProps) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ token, password }),
     });
-
-    setMessage(res.ok ? "Password updated" : "Error");
+    if (res.ok) {
+      const data = await res.json().catch(() => null);
+      if (data?.redirect) {
+        window.location.href = data.redirect;
+        return;
+      }
+      setMessage("Password updated");
+    } else {
+      const data = await res.json().catch(() => null);
+      setMessage(data?.error || "Error");
+    }
   }
 
   return (

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -5,7 +5,14 @@ interface PageProps {
 }
 
 export default function Page({ searchParams }: PageProps) {
-  const token = searchParams.token ?? "";
+  const token = searchParams.token;
+  if (!token) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <p>Invalid or expired link</p>
+      </div>
+    );
+  }
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <SetPasswordForm token={token} />


### PR DESCRIPTION
## Summary
- display error when set-password link lacks a valid token
- redirect to course after setting password via token-based API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad331dff1883278803735aa8a1bec5