### PR TITLE
docs(test): Razorpay webhook + password flows checklist

### DIFF
--- a/tests/payment-webhook.md
+++ b/tests/payment-webhook.md
@@ -1,0 +1,14 @@
+# Payment webhook test checklist
+
+## Razorpay test mode
+
+- Create a Payment Link that requires email.
+- In Razorpay Webhooks: URL https://thefacemax.com/api/webhook/payment, secret matches RAZORPAY_WEBHOOK_SECRET, select `payment.captured`.
+- Pay using test card, complete capture.
+- Verify in DB: users.purchased=true for that email; payments row present.
+- Check email (Resend logs) → open set-password link → set password → redirect to /course.
+- Logout → Login with password → you should enter OTP (existing flow) and access /course.
+
+## Forgot password
+
+- Use the same email → request reset at /auth/forgot-password → receive mail → set new password → login OK.


### PR DESCRIPTION
## Summary
- document Razorpay test-mode webhook and password reset flows in a new checklist

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad3806e0988327b82a47537a6ae3d2