### PR TITLE
Add Razorpay checkout form

### DIFF
--- a/app/marketing/BuyNow.tsx
+++ b/app/marketing/BuyNow.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React, { useState } from "react";
+
+export default function BuyNow() {
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/payments/create-order", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, name }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Payment error");
+      }
+
+      const openCheckout = () => {
+        const rzp = new (window as any).Razorpay({
+          key: data.keyId,
+          amount: data.amount,
+          currency: data.currency,
+          order_id: data.orderId,
+          name: "The Ultimate Implant Course",
+          description: "Lifetime access",
+          prefill: { email, name },
+          notes: { email, name },
+          theme: { color: "#111827" },
+          handler: () => {
+            setMessage(
+              "Payment received — check your email for login instructions."
+            );
+          },
+          modal: {
+            ondismiss: () => setLoading(false),
+          },
+        });
+        rzp.open();
+        setLoading(false);
+      };
+
+      if (typeof window !== "undefined") {
+        if ((window as any).Razorpay) {
+          openCheckout();
+        } else {
+          const script = document.createElement("script");
+          script.src = "https://checkout.razorpay.com/v1/checkout.js";
+          script.onload = openCheckout;
+          script.onerror = () => {
+            setError("Failed to load payment script.");
+            setLoading(false);
+          };
+          document.body.appendChild(script);
+        }
+      }
+    } catch (e: any) {
+      setError(e.message || "Something went wrong");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
+      <div>
+        <label className="block text-sm font-medium text-slate-700">
+          Email
+        </label>
+        <input
+          type="email"
+          required
+          className="mt-1 w-full rounded-md border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700">
+          Name (optional)
+        </label>
+        <input
+          type="text"
+          className="mt-1 w-full rounded-md border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {message && <p className="text-sm text-green-600">{message}</p>}
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full rounded-md bg-slate-900 px-4 py-2 text-white font-semibold hover:bg-slate-800 disabled:opacity-50"
+      >
+        {loading ? "Processing..." : "Buy Now"}
+      </button>
+    </form>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import ImplantHero from "./components/ImplantHero";
 import DealCountdown from "./components/DealCountdown";
 import TrailerModal from "./components/TrailerModal";
 import GeoPrice from "./components/GeoPrice";
+import BuyNow from "./marketing/BuyNow";
 
 /* ===== Clean, balanced icons (kept for future use if needed) ===== */
 const _IconImplant = (props: React.SVGProps<SVGSVGElement>) => (
@@ -449,6 +450,16 @@ export default function Page() {
                 <p className="mt-2 text-xs text-slate-500">Includes certificate • Lifetime updates • 50% off on all future courses</p>
               </div>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Checkout */}
+      <section id="checkout" className="py-16 bg-gray-50">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold text-center">Enroll now – $299</h2>
+          <div className="mt-8">
+            <BuyNow />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add client BuyNow form with Razorpay checkout
- show enroll section on marketing page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad4d858c10832787f1ead57cf54520