### PR TITLE
Switch to UUID ids and secure Razorpay webhook

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -16,8 +16,13 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: true });
     }
 
-    const rows = (await sql`SELECT purchased FROM users WHERE email=${emailLower} LIMIT 1;`) as { purchased: boolean }[];
-    if (rows.length === 1 && rows[0].purchased) {
+    const rows = (await sql`
+      SELECT 1 as ok FROM purchases p
+      JOIN users u ON u.id = p.user_id
+      WHERE u.email=${emailLower}
+      LIMIT 1;
+    `) as { ok: number }[];
+    if (rows.length === 1) {
       const token = await issuePasswordToken(emailLower, 'reset', 60);
       const appUrl = process.env.APP_URL || 'https://thefacemax.com';
       const link = `${appUrl}/auth/set-password?token=${token}`;

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -4,7 +4,7 @@ export const dynamic = 'force-dynamic';
 import { NextResponse } from 'next/server';
 import { sql } from '@/app/lib/db';
 import { ensureTables } from '@/app/lib/bootstrap';
-import { verifyPassword, hashToken, randomId } from '@/app/lib/crypto';
+import { verifyPassword, hashToken } from '@/app/lib/crypto';
 import { generateOtp, expiresIn } from '@/app/lib/otp';
 import { sendEmail } from '@/app/lib/email';
 
@@ -20,8 +20,7 @@ export async function POST(req: Request) {
 
   const code = generateOtp(6);
   const exp = expiresIn(10);
-  const otpId = randomId();
-  await sql`INSERT INTO otps(id, user_id, code_hash, purpose, expires_at) VALUES(${otpId}, ${user.id}, ${hashToken(code)}, 'login', ${exp});`;
+  await sql`INSERT INTO otps(user_id, code_hash, purpose, expires_at) VALUES(${user.id}, ${hashToken(code)}, 'login', ${exp});`;
 
   await sendEmail(email, 'Your FaceMax login code', `
     <p>Hello ${user.name},</p>

--- a/app/api/webhook/payment/route.ts
+++ b/app/api/webhook/payment/route.ts
@@ -4,122 +4,87 @@ import { NextResponse } from 'next/server';
 import crypto from 'crypto';
 import { sql } from '@/app/lib/db';
 import { ensureTables } from '@/app/lib/bootstrap';
-import { randomId, issuePasswordToken } from '@/app/lib/crypto';
+import { issuePasswordToken } from '@/app/lib/crypto';
 import { sendMail } from '@/app/lib/email';
 import { COURSE_ID } from '@/app/lib/course-ids';
 
-let schemaChecked = false;
-async function checkSchema() {
-  if (schemaChecked) return;
-  schemaChecked = true;
-  try {
-    await sql`SELECT id, email, name FROM users LIMIT 1;`;
-  } catch (err) {
-    console.error('[webhook] users schema mismatch', err);
-  }
-}
-
 export async function POST(req: Request) {
-  console.info('[webhook] received');
-  const raw = await req.text();
-  const sig = req.headers.get('x-razorpay-signature') ?? '';
-  const secret = process.env.RAZORPAY_WEBHOOK_SECRET || '';
-  const expected = crypto.createHmac('sha256', secret).update(raw, 'utf8').digest('hex');
-  let valid = false;
-  if (sig.length === expected.length) {
-    valid = crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
-  }
-  if (!valid) {
-    console.warn('[webhook] invalid signature');
-    return NextResponse.json(
-      { ok: false, error: 'INVALID_SIGNATURE' },
-      { status: 400 }
-    );
-  }
-
-  let evt: any;
+  const reqId = crypto.randomUUID();
   try {
-    evt = JSON.parse(raw);
-  } catch (err) {
-    console.error('[webhook] parse failed', err);
-    return NextResponse.json({ ok: true });
-  }
-
-  console.info('[webhook] signature ok', { event: evt.event });
-  if (evt.event !== 'payment.captured') {
-    return NextResponse.json({ ok: true });
-  }
-
-  await ensureTables();
-  await checkSchema();
-
-  const entity = evt.payload?.payment?.entity ?? {};
-  const email = (entity.email || entity.notes?.email || '').toLowerCase();
-  if (!email) {
-    return NextResponse.json({ ok: true, note: 'no email' });
-  }
-  const name = entity.notes?.name || entity.contact_name || '';
-  const paymentId = entity.id;
-  const amount = entity.amount;
-  const currency = entity.currency;
-
-  let userId: string | undefined;
-  try {
-    const rows = (await sql`
-      INSERT INTO users (id, email, name, purchased)
-      VALUES (${randomId()}, ${email}, ${name}, true)
-      ON CONFLICT (email) DO UPDATE
-      SET name = COALESCE(EXCLUDED.name, users.name),
-          purchased = true
-      RETURNING id;
-    `) as { id: string }[] | undefined;
-    userId = Array.isArray(rows) ? rows[0]?.id : undefined;
-    console.info('[webhook] user upsert', { userId });
-  } catch (err) {
-    console.error('[webhook] write failed', err);
-  }
-
-  let newPurchase = false;
-  if (userId) {
-    try {
-      const res = (await sql`
-        INSERT INTO purchases(user_id, course_id, payment_id)
-        VALUES(${userId}, ${COURSE_ID}, ${paymentId})
-        ON CONFLICT (payment_id) DO NOTHING
-        RETURNING 1;
-      `) as unknown[] | undefined;
-      newPurchase = Array.isArray(res) && res.length > 0;
-    } catch (err) {
-      console.error('[webhook] write failed', err);
+    const raw = await req.text();
+    const sig = req.headers.get('x-razorpay-signature') || '';
+    const secret = process.env.RAZORPAY_WEBHOOK_SECRET || '';
+    const expected = crypto
+      .createHmac('sha256', secret)
+      .update(raw)
+      .digest('hex');
+    const valid =
+      sig &&
+      expected.length === sig.length &&
+      crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
+    if (!valid) {
+      console.warn(`[webhook ${reqId}] invalid signature`);
+      return NextResponse.json({ ok: false }, { status: 400 });
     }
-  }
 
-  try {
+    const evt = JSON.parse(raw);
+    if (evt.event !== 'payment.captured') {
+      return NextResponse.json({ ok: true });
+    }
+
+    await ensureTables();
+
+    const entity = evt.payload?.payment?.entity || {};
+    const email = (entity.email || entity.notes?.email || '').toLowerCase();
+    if (!email) {
+      console.error(`[webhook ${reqId}] missing email`);
+      return NextResponse.json({ ok: true });
+    }
+    const name = entity.notes?.name || entity.contact_name || null;
+    const amount = entity.amount || 0;
+    const currency = entity.currency || 'INR';
+    const paymentId = entity.id || '';
+
+    const rows = (await sql`
+      INSERT INTO users(email, name)
+      VALUES(${email}, ${name || 'Customer'})
+      ON CONFLICT (email) DO UPDATE
+      SET name = COALESCE(users.name, EXCLUDED.name)
+      RETURNING id;
+    `) as { id: string }[];
+    const userId = rows[0].id;
+
+    const payRows = (await sql`
+      INSERT INTO payments(user_id, provider, provider_payment_id, amount_cents, currency)
+      VALUES(${userId}, 'razorpay', ${paymentId}, ${amount}, ${currency})
+      ON CONFLICT (provider_payment_id) DO NOTHING
+      RETURNING id;
+    `) as { id: string }[];
+    if (payRows.length === 0) {
+      console.info(`[webhook ${reqId}] payment already processed`);
+      return NextResponse.json({ ok: true });
+    }
+
     await sql`
-      INSERT INTO payments(id, provider, email, amount, currency, payload)
-      VALUES(${paymentId}, 'razorpay', ${email}, ${amount}, ${currency}, ${evt})
+      INSERT INTO purchases(user_id, product, amount_cents, currency)
+      VALUES(${userId}, ${COURSE_ID}, ${amount}, ${currency})
       ON CONFLICT DO NOTHING;
     `;
+
+    const token = await issuePasswordToken(email, 'set', 120);
+    const appUrl = process.env.APP_URL || 'https://thefacemax.com';
+    const link = `${appUrl}/auth/set-password?token=${token}`;
+    await sendMail(
+      email,
+      'Welcome to The Ultimate Implant Course',
+      `<p>Welcome to The Ultimate Implant Course.</p><p><a href="${link}">Click here to set your password</a>. This link is valid for 2 hours.</p>`
+    );
+
+    console.info(`[webhook ${reqId}] processed ${paymentId}`);
+    return NextResponse.json({ ok: true });
   } catch (err) {
-    console.error('[webhook] write failed', err);
+    console.error(`[webhook ${reqId}] error`, err);
+    return NextResponse.json({ ok: false }, { status: 500 });
   }
-
-  if (newPurchase) {
-    try {
-      const token = await issuePasswordToken(email, 'set', 120);
-      const appUrl = process.env.APP_URL || 'https://thefacemax.com';
-      const link = `${appUrl}/auth/set-password?token=${token}`;
-      await sendMail(
-        email,
-        'Welcome to The Ultimate Implant Course',
-        `<p>Welcome to The Ultimate Implant Course.</p><p><a href="${link}">Click here to set your password</a>. This link is valid for 2 hours.</p>`
-      );
-      console.info('[webhook] email sent', { email });
-    } catch (err) {
-      console.error('[webhook] email failed', err);
-    }
-  }
-
-  console.info('[webhook] processed', { payment_id: paymentId });
-  return NextResponse.json({ ok: true }, { status: 200 });
 }
+

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -83,16 +83,26 @@ export async function POST(req: Request) {
     let userId: string;
     let userName: string;
     if (existing.length === 0) {
-      userId = randomId();
       userName = name || emailLower;
       const fakeHash = await hashPassword(randomId());
-      await sql`INSERT INTO users(id, email, name, password_hash) VALUES(${userId}, ${emailLower}, ${userName}, ${fakeHash});`;
+      const rows = (await sql`
+        INSERT INTO users(email, name, password_hash)
+        VALUES(${emailLower}, ${userName}, ${fakeHash})
+        RETURNING id;
+      `) as { id: string }[];
+      userId = rows[0].id;
     } else {
       userId = existing[0].id;
       userName = existing[0].name;
     }
 
-    await sql`INSERT INTO purchases(user_id, course_id) VALUES(${userId}, ${COURSE_ID}) ON CONFLICT DO NOTHING;`;
+    const amount = obj.amount_total || obj.amount || 0;
+    const currency = obj.currency || 'usd';
+    await sql`
+      INSERT INTO purchases(user_id, product, amount_cents, currency)
+      VALUES(${userId}, ${COURSE_ID}, ${amount}, ${currency})
+      ON CONFLICT DO NOTHING;
+    `;
 
     const token = randomId();
     const tokenHash = hashToken(token);

--- a/app/lib/access.ts
+++ b/app/lib/access.ts
@@ -2,10 +2,10 @@ import 'server-only';
 import { sql } from '@/app/lib/db';
 import { ensureTables } from '@/app/lib/bootstrap';
 
-export async function userHasPurchase(userId: string, courseId: string): Promise<boolean> {
+export async function userHasPurchase(userId: string, product: string): Promise<boolean> {
   await ensureTables();
   const rows = (await sql`
-    SELECT 1 as ok FROM purchases WHERE user_id=${userId} AND course_id=${courseId} LIMIT 1;
+    SELECT 1 as ok FROM purchases WHERE user_id=${userId} AND product=${product} LIMIT 1;
   `) as { ok: number }[];
   return rows.length > 0;
 }


### PR DESCRIPTION
## Summary
- migrate users, purchases, payments and otps tables to UUID schema with cascades
- remove manual id generation and use INSERT ... RETURNING for user, payment and purchase records
- harden Razorpay payment webhook with signature verification, user upsert, payment log and welcome email
- add tests covering webhook flow and UUID upsert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf5e4167c8327910f004e6e80e497