### PR TITLE
chore(db): use POSTGRES_URL with clear error

### DIFF
--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,3 +1,11 @@
+// app/lib/db.ts
 import { neon } from '@neondatabase/serverless';
-if (!process.env.POSTGRES_URL) throw new Error('POSTGRES_URL missing');
-export const sql = neon(process.env.POSTGRES_URL);
+
+const url = process.env.POSTGRES_URL;
+if (!url || url.trim() === '') {
+  // Keep this exact message; our monitoring looks for it.
+  throw new Error('POSTGRES_URL missing');
+}
+
+// Create a single Neon client for the serverless function runtime
+export const sql = neon(url);

--- a/tests/admin-sections.test.ts
+++ b/tests/admin-sections.test.ts
@@ -9,7 +9,7 @@ jest.mock('next/server', () => ({
 
 jest.mock('server-only', () => ({}), { virtual: true });
 
-jest.mock('../app/lib/db', () => ({
+jest.mock('@/app/lib/db', () => ({
   sql: jest.fn(),
 }));
 
@@ -28,7 +28,7 @@ jest.mock('../app/lib/crypto', () => ({
 import { POST } from '../app/api/admin/sections/route';
 import { getCourseData } from '../app/lib/course-data';
 
-const { sql } = require('../app/lib/db');
+const { sql } = require('@/app/lib/db');
 const { getSession } = require('../app/lib/cookies');
 
 beforeEach(() => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -9,7 +9,7 @@ jest.mock('next/server', () => ({
 
 jest.mock('server-only', () => ({}), { virtual: true });
 
-jest.mock('../app/lib/db', () => ({
+jest.mock('@/app/lib/db', () => ({
   sql: jest.fn(),
 }));
 
@@ -58,7 +58,7 @@ import { POST as CreateOrder } from '../app/api/payments/create/route';
 import { POST as AdminInvite } from '../app/api/admin/invite/route';
 import { POST as ForgotPassword } from '../app/api/auth/forgot-password/route';
 
-const { sql } = require('../app/lib/db');
+const { sql } = require('@/app/lib/db');
 const { getSession } = require('../app/lib/cookies');
 const { userHasPurchase } = require('../app/lib/access');
 const { getCourseData } = require('../app/lib/course-data');


### PR DESCRIPTION
## Summary
- use POSTGRES_URL for Neon connection and fail loudly when missing
- align tests to mock the shared db helper

## Testing
- `POSTGRES_URL=postgres://user:pass@localhost/db npm test`
- `POSTGRES_URL=postgres://user:pass@localhost/db RESEND_API_KEY=dummy RESEND_FROM=test@example.com npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae0d353cf08327b69c206129f68976