### PR TITLE
Use shared promise to serialize schema bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ When switching modes in the Razorpay dashboard, update the variables above in Ve
 
 ## Database schema
 
-The application bootstraps its PostgreSQL schema at runtime via `ensureTables()` in `app/lib/bootstrap.ts`. It creates or updates the following tables:
+The application bootstraps its PostgreSQL schema at runtime via `ensureTables` in `app/lib/bootstrap.ts`. It creates or updates the following tables:
 
 - **users**: `id` UUID primary key, `email` unique lowercase text, optional `name` and `phone`, `is_admin` boolean, `password_hash`, `created_at` timestamp.
 - **purchases**: records entitlements with `user_id` UUID FK to `users`, `product`, `amount_cents`, `currency`, `provider`, optional `provider_order_id`, `created_at`.
 - **payments**: logs payment events with `user_id` UUID FK, `provider`, `provider_payment_id`, `status`, `amount_cents`, `currency`, raw JSON payload, `created_at`, and uniqueness on `(provider, provider_payment_id)`.
 
-Run the migration locally by importing and executing `ensureTables()` or starting the dev server. On deploy, this function runs automatically to keep the schema in sync.
+Run the migration locally by importing and awaiting `ensureTables` or starting the dev server. On deploy, this promise runs automatically to keep the schema in sync.
 
 ## Schema guard
 
-`ensureTables()` also acts as a schema guard. On startup it adds missing `user_id` columns to `payments` and `purchases`, wires their foreign keys to `users(id)` with `ON DELETE CASCADE`, ensures the `users` table exists with required fields, and maintains a unique index on `lower(email)`.
+`ensureTables` also acts as a schema guard. On startup it adds missing `user_id` columns to `payments` and `purchases`, wires their foreign keys to `users(id)` with `ON DELETE CASCADE`, ensures the `users` table exists with required fields, and maintains a unique index on `lower(email)`.

--- a/app/admin/course/page.tsx
+++ b/app/admin/course/page.tsx
@@ -13,7 +13,7 @@ export default async function AdminCoursePage() {
     return <div style={{ padding: 24 }}>Unauthorized</div>;
   }
 
-  await ensureTables();
+  await ensureTables;
   const { sections, lectures } = await getData();
 
   return (

--- a/app/api/admin/invite/route.ts
+++ b/app/api/admin/invite/route.ts
@@ -15,7 +15,7 @@ import { setPasswordEmail } from '@/app/emails/set-password';
 export async function POST(req: Request) {
   try {
     requireAdminEmail();
-    await ensureTables();
+    await ensureTables;
 
     const body = await req.json().catch(() => ({} as any));
     const email = (body.email ?? '').toString().trim().toLowerCase();

--- a/app/api/admin/lectures/route.ts
+++ b/app/api/admin/lectures/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
       return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    await ensureTables();
+    await ensureTables;
 
     const rows = (await sql`
       SELECT id, section_id, title, order_index, video_id, duration_min
@@ -48,7 +48,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    await ensureTables();
+    await ensureTables;
 
     const body = await req.json().catch(() => ({} as any));
     const sectionId = (body.sectionId ?? "").toString().trim();

--- a/app/api/admin/sections/route.ts
+++ b/app/api/admin/sections/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
       return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    await ensureTables();
+    await ensureTables;
 
     const rows = (await sql`
       SELECT id, title, order_index
@@ -40,7 +40,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    await ensureTables();
+    await ensureTables;
 
     const { title, orderIndex } = await req.json().catch(() => ({} as any));
     const name = (title ?? "").toString().trim();

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -9,7 +9,7 @@ import { sendMail } from '@/app/lib/email';
 
 export async function POST(req: Request) {
   try {
-    await ensureTables();
+    await ensureTables;
     const { email } = await req.json().catch(() => ({}) as any);
     const emailLower = (email ?? '').toString().trim().toLowerCase();
     if (!emailLower) {

--- a/app/api/auth/login-otp/route.ts
+++ b/app/api/auth/login-otp/route.ts
@@ -8,7 +8,7 @@ import { hashToken } from '@/app/lib/crypto';
 import { setSession } from '@/app/lib/cookies';
 
 export async function POST(req: Request) {
-  await ensureTables();
+  await ensureTables;
   const { email, code } = await req.json();
   if (!email || !code) return NextResponse.json({ error: 'Email and code required' }, { status: 400 });
   const users = (await sql`SELECT id, name, email FROM users WHERE email=${email.toLowerCase()} LIMIT 1;`) as { id: string; name: string; email: string }[];

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -9,7 +9,7 @@ import { generateOtp, expiresIn } from '@/app/lib/otp';
 import { sendEmail } from '@/app/lib/email';
 
 export async function POST(req: Request) {
-  await ensureTables();
+  await ensureTables;
   const { email, password } = await req.json();
   if (!email || !password) return NextResponse.json({ error: 'Email and password required' }, { status: 400 });
   const rows = (await sql`SELECT id, name, password_hash FROM users WHERE email=${email.toLowerCase()} LIMIT 1;`) as { id: string; name: string; password_hash: string }[];

--- a/app/api/auth/set-password/route.ts
+++ b/app/api/auth/set-password/route.ts
@@ -8,7 +8,7 @@ import { hashPassword, consumePasswordToken } from '@/app/lib/crypto';
 import { setSession } from '@/app/lib/cookies';
 
 export async function POST(req: Request) {
-  await ensureTables();
+  await ensureTables;
   const { token, password } = await req.json().catch(() => ({}) as any);
   if (!token || !password) {
     return NextResponse.json(

--- a/app/api/webhook/payment/route.ts
+++ b/app/api/webhook/payment/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: true });
     }
 
-    await ensureTables();
+    await ensureTables;
 
     const entity = evt.payload?.payment?.entity || {};
     const email = (entity.email || entity.notes?.email || entity.contact || '').toLowerCase();

--- a/app/api/webhooks/razorpay/route.ts
+++ b/app/api/webhooks/razorpay/route.ts
@@ -57,7 +57,7 @@ export async function POST(req: Request) {
       payment.notes?.name || payment.card?.name || order.notes?.name || '';
     if (!email) return NextResponse.json({ ok: true });
 
-    await ensureTables();
+    await ensureTables;
     const emailLower = email.toLowerCase();
     const existing = (await sql`SELECT id, name FROM users WHERE email=${emailLower} LIMIT 1;`) as {
       id: string;

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -74,7 +74,7 @@ export async function POST(req: Request) {
     const name = obj.customer_details?.name || obj.customer_name || '';
     if (!email) return NextResponse.json({ ok: true });
 
-    await ensureTables();
+    await ensureTables;
     const emailLower = email.toLowerCase();
     const existing = (await sql`SELECT id, name FROM users WHERE email=${emailLower} LIMIT 1;`) as {
       id: string;

--- a/app/lib/access.ts
+++ b/app/lib/access.ts
@@ -3,7 +3,7 @@ import { sql } from '@/app/lib/db';
 import { ensureTables } from '@/app/lib/bootstrap';
 
 export async function userHasPurchase(userId: string, product: string): Promise<boolean> {
-  await ensureTables();
+  await ensureTables;
   const rows = (await sql`
     SELECT 1 as ok FROM purchases WHERE user_id=${userId} AND product=${product} LIMIT 1;
   `) as { ok: number }[];

--- a/app/lib/bootstrap.ts
+++ b/app/lib/bootstrap.ts
@@ -1,10 +1,7 @@
 // app/lib/bootstrap.ts
 import { sql } from "@/app/lib/db";
 
-let done = false;
-
-export async function ensureTables() {
-  if (done) return;
+export const ensureTables: Promise<void> = (async () => {
 
   // Guard constraints via pg_constraint so boot can run on every request without errors.
 
@@ -177,6 +174,4 @@ export async function ensureTables() {
     );
   `;
   await sql`CREATE INDEX IF NOT EXISTS idx_password_tokens_email ON password_tokens(email);`;
-
-  done = true;
-}
+})();

--- a/app/lib/course-data.ts
+++ b/app/lib/course-data.ts
@@ -33,7 +33,7 @@ export type CourseData = Array<{
 
 export async function getCourseData(): Promise<CourseData> {
   try {
-    await ensureTables();
+    await ensureTables;
 
     const sections = (await sql`
       SELECT id, title, order_index

--- a/tests/admin-sections.test.ts
+++ b/tests/admin-sections.test.ts
@@ -14,7 +14,7 @@ jest.mock('@/app/lib/db', () => ({
 }));
 
 jest.mock('../app/lib/bootstrap', () => ({
-  ensureTables: jest.fn().mockResolvedValue(undefined),
+  ensureTables: Promise.resolve(),
 }));
 
 jest.mock('../app/lib/cookies', () => ({

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -14,7 +14,7 @@ jest.mock('@/app/lib/db', () => ({
 }));
 
 jest.mock('../app/lib/bootstrap', () => ({
-  ensureTables: jest.fn().mockResolvedValue(undefined),
+  ensureTables: Promise.resolve(),
 }));
 
 jest.mock('../app/lib/email', () => ({


### PR DESCRIPTION
## Summary
- ensureTables now exports a single Promise so concurrent callers share schema initialization
- update all routes and helpers to await the shared promise
- adjust tests and docs accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae27ae79348327b81a112add0a3b7a