### PR TITLE
Lock OTP constraint creation to prevent races

### DIFF
--- a/app/lib/bootstrap.ts
+++ b/app/lib/bootstrap.ts
@@ -51,6 +51,7 @@ export async function ensureTables() {
   await sql`
     DO $$
     BEGIN
+      LOCK TABLE otps IN ACCESS EXCLUSIVE MODE;
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint WHERE conname = 'otps_user_id_fkey'
       ) THEN

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-config-next": "^14.2.5",
         "jest": "^30.0.5",
         "postcss": "8.4.38",
+        "postgres": "^3.4.7",
         "tailwindcss": "3.4.7",
         "ts-jest": "^29.4.1",
         "typescript": "5.4.5"
@@ -7502,6 +7503,20 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postgres": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
+      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,15 +23,16 @@
     "@types/jest": "^30.0.0",
     "@types/node": "20.12.7",
     "@types/react": "18.2.73",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
     "autoprefixer": "10.4.19",
-    "jest": "^30.0.5",
-    "postcss": "8.4.38",
-    "tailwindcss": "3.4.7",
-    "ts-jest": "^29.4.1",
-    "typescript": "5.4.5",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.5",
-    "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@typescript-eslint/parser": "^7.18.0"
+    "jest": "^30.0.5",
+    "postcss": "8.4.38",
+    "postgres": "^3.4.7",
+    "tailwindcss": "3.4.7",
+    "ts-jest": "^29.4.1",
+    "typescript": "5.4.5"
   }
 }

--- a/tests/ensureTables-concurrency.test.ts
+++ b/tests/ensureTables-concurrency.test.ts
@@ -1,0 +1,29 @@
+import postgres from 'postgres';
+
+const pgSql = postgres({ host: 'localhost', username: 'postgres', password: 'postgres', database: 'postgres' });
+
+jest.mock('@/app/lib/db', () => ({ sql: pgSql }));
+
+async function loadBootstrap() {
+  delete require.cache[require.resolve('@/app/lib/bootstrap')];
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('@/app/lib/bootstrap');
+}
+
+describe('ensureTables concurrency', () => {
+  beforeAll(async () => {
+    await pgSql`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`;
+    const { ensureTables } = await loadBootstrap();
+    await ensureTables();
+    await pgSql`ALTER TABLE otps DROP CONSTRAINT IF EXISTS otps_user_id_fkey`;
+  });
+
+  afterAll(async () => {
+    await pgSql.end({ timeout: 5 });
+  });
+
+  it('runs twice in parallel without errors', async () => {
+    const { ensureTables } = await loadBootstrap();
+    await Promise.all([ensureTables(), ensureTables()]);
+  });
+});


### PR DESCRIPTION
## Summary
- lock `otps` table before adding `user_id` FK
- add Jest test exercising concurrent `ensureTables`
- add `postgres` dev dependency for test DB access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae27d218c48327ab97eafabf37b9d4