### PR TITLE
Fix Razorpay webhook upsert and welcome email

### DIFF
--- a/app/api/test-email/route.ts
+++ b/app/api/test-email/route.ts
@@ -3,7 +3,8 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import { NextResponse } from 'next/server';
-import { sendEmail } from '../../lib/email'; // <-- relative path
+import { sendWelcomeEmail } from '@/app/lib/email';
+import { randomId } from '@/app/lib/crypto';
 
 export async function GET(req: Request) {
   try {
@@ -13,11 +14,8 @@ export async function GET(req: Request) {
       return NextResponse.json({ ok: false, error: "missing ?to=" }, { status: 400 });
     }
 
-    const r = await sendEmail(
-      to,
-      'The Face Max — test email ✅',
-      `<p>Hello from the site. If you got this, Resend + domain setup works.</p>`
-    );
+    const token = randomId(32);
+    const r = await sendWelcomeEmail({ to, name: null, token });
     return NextResponse.json({ ok: true, result: r });
   } catch (e: any) {
     console.error(e);

--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -20,5 +20,30 @@ export async function sendMail(to: string, subject: string, html: string) {
   });
 }
 
+export async function sendWelcomeEmail({
+  to,
+  name,
+  token,
+}: {
+  to: string;
+  name?: string | null;
+  token: string;
+}) {
+  const from = process.env.MAIL_FROM;
+  if (!process.env.RESEND_API_KEY || !from) {
+    throw new Error('Missing RESEND_API_KEY or MAIL_FROM');
+  }
+  const link = `https://www.thefacemax.com/auth/set-password?token=${token}`;
+  const subject = 'Welcome to The Ultimate Implant Course';
+  const greet = name ? `Hi ${name},` : 'Hi,';
+  const html = `
+    <p>${greet}</p>
+    <p>Welcome to The Ultimate Implant Course.</p>
+    <p><a href="${link}" style="display:inline-block;padding:10px 16px;background-color:#2563EB;color:#fff;text-decoration:none;border-radius:4px">Set your password</a></p>
+  `;
+  const text = `${greet}\n\nWelcome to The Ultimate Implant Course.\nSet your password: ${link}\n`;
+  return await resend.emails.send({ from, to, subject, html, text });
+}
+
 // Backwards compatibility
 export { sendMail as sendEmail };


### PR DESCRIPTION
## Summary
- verify Razorpay webhook signatures against the raw request body
- upsert users, log payments and purchases idempotently
- send welcome emails with password-set links via Resend

## Testing
- `npm run lint`
- `POSTGRES_URL=postgres://localhost NEXT_TELEMETRY_DISABLED=1 npm run build` *(fails: process hung in container)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c5abf1108327bae4c6e49ef981b7